### PR TITLE
Pirate Weapons Vendor

### DIFF
--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -42,7 +42,8 @@
 		H.equip_if_possible(new /obj/item/storage/backpack(H), H.slot_back)
 		H.equip_if_possible(new /obj/item/reagent_containers/food/drinks/flask/pirate(H), H.slot_in_backpack)
 		H.equip_if_possible(new /obj/item/clothing/glasses/eyepatch/pirate(H), H.slot_glasses)
-		H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended(H), H.slot_r_store)
+		H.equip_if_possible(new /obj/item/requisition_token/pirate(H), H.slot_r_store)
+		H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended(H), H.slot_l_store)
 		H.equip_if_possible(new /obj/item/swords_sheaths/pirate(H), H.slot_belt)
 
 		H.equip_sensory_items()

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -638,6 +638,25 @@
 		/obj/item/clothing/suit/space/syndicate/specialist/bard,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/bard)
 
+	pirate
+		icon = 'icons/obj/large/32x48.dmi'
+		icon_state = "chest"
+		icon_opened = "chest-open"
+		icon_closed = "chest"
+
+		musketeer
+			name = "Class Chest - Musketeer"
+			desc = "A chest containing a Pirate Musketeer loadout."
+			spawn_contents = list(/obj/item/gun/kinetic/single_action/flintlock/rifle,
+			/obj/item/storage/backpack/satchel/flintlock_satchel)
+
+		buccaneer
+			name = "Class Chest - Buccaneer"
+			desc = "A chest containing a Pirate Buccaneer loadout."
+			spawn_contents = list(/obj/item/gun/kinetic/single_action/flintlock,
+			/obj/item/gun/kinetic/single_action/flintlock,
+			/obj/item/ammo/bullets/flintlock)
+
 	qm //Hi Gannets, I like your crate and wanted to use it for some QM stuff. Come yell at Azungar if this is not ok.
 		name = "Weapons crate"
 		desc = "Just a fancy crate that may or may not contain weapons."

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -211,6 +211,26 @@
 		STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
 		..()
 
+/obj/submachine/weapon_vendor/pirate
+	name = "Pirate Weapons Vendor"
+	icon = 'icons/obj/vending.dmi'
+	icon_state = "weapon"
+	desc = "An automated quartermaster service for supplying your pirate crew with weapons and gear."
+	token_accepted = /obj/item/requisition_token/pirate
+	log_purchase = TRUE
+
+	ex_act()
+		return
+
+	New()
+		materiel_stock += new/datum/materiel/loadout/musketeer
+		materiel_stock += new/datum/materiel/loadout/buccaneer
+		..()
+
+	accepted_token()
+		src.credits[WEAPON_VENDOR_CATEGORY_LOADOUT]++
+		..()
+
 // Materiel avaliable for purchase:
 
 /datum/materiel
@@ -489,6 +509,19 @@
 	name = "Sawfly pouch"
 	path = /obj/item/storage/sawfly_pouch
 	description = "A pouch of 3 reusable anti-personnel drones."
+
+// PIRATE
+
+/datum/materiel/loadout/musketeer
+	name = "Musketeer"
+	path = /obj/storage/crate/classcrate/pirate/musketeer
+	description = "Flintlock rifle and 15 rounds of ammunition provided in a specialised satchel."
+
+/datum/materiel/loadout/buccaneer
+	name = "Buccaneer"
+	path = /obj/storage/crate/classcrate/pirate/buccaneer
+	description = "A set of two flintlock pistols and 15 rounds of ammunition."
+
 // Requisition tokens
 
 /obj/item/requisition_token
@@ -518,6 +551,11 @@
 		utility
 			desc = "An NT-provided token that entitles the owner to one additional utility purchase."
 			icon_state = "req-token-secass"
+
+	pirate
+		name = "doubloon"
+		desc = "A finely stamped gold coin compatible with the Pirate Weapons Vendor."
+		icon_state = "req-token"
 
 #undef WEAPON_VENDOR_CATEGORY_SIDEARM
 #undef WEAPON_VENDOR_CATEGORY_LOADOUT


### PR DESCRIPTION
`/obj/submachine/weapon_vendor/pirate` exists now with two loadouts loaded:
- Musketeer: armed with a flintlock rifle, specialised satchel, and 15 rounds of ammunition.
- Buccaneer: armed with two flintlock pistols and 15 rounds of ammunition.

Each pirate spawns with a loadout token `/obj/item/requisition_token/pirate`.

Both of these objects presently use placeholder icon_states.