### PR TITLE
Afterlife bar gets the ':d' deadchat radio prefix

### DIFF
--- a/code/modules/speech/core.dm
+++ b/code/modules/speech/core.dm
@@ -157,7 +157,6 @@ Cleanup:
 
 Things To Implement:
 - AI
-- Virtual humans
 - Observers (not ghosts)
 - Skeleton heads
 - Ghostdrones (language)

--- a/code/modules/speech/modules/outputs/spoken/_spoken.dm
+++ b/code/modules/speech/modules/outputs/spoken/_spoken.dm
@@ -19,7 +19,6 @@
 		message.flags |= SAYFLAG_DELIMITED_CHANNEL_ONLY
 
 	global.SpeechManager.ProcessMessagePrefix(message, src.parent_tree)
-
 	if (QDELETED(message))
 		return
 

--- a/code/modules/speech/modules/outputs/spoken/_spoken.dm
+++ b/code/modules/speech/modules/outputs/spoken/_spoken.dm
@@ -20,6 +20,9 @@
 
 	global.SpeechManager.ProcessMessagePrefix(message, src.parent_tree)
 
+	if (QDELETED(message))
+		return
+
 	. = ..()
 
 /datum/speech_module/output/spoken/proc/format(datum/say_message/message)

--- a/code/modules/speech/prefixes/deadchat.dm
+++ b/code/modules/speech/prefixes/deadchat.dm
@@ -5,7 +5,5 @@
 	return ismob(message.speaker) && inafterlife(message.speaker)
 
 /datum/say_prefix/deadchat/process(datum/say_message/message, datum/speech_module_tree/say_tree)
-
 	say_tree.GetOutputByID(SPEECH_OUTPUT_DEADCHAT)?.process(message.Copy())
-	
 	qdel(message)

--- a/code/modules/speech/prefixes/deadchat.dm
+++ b/code/modules/speech/prefixes/deadchat.dm
@@ -5,6 +5,7 @@
 	return ismob(message.speaker) && inafterlife(message.speaker)
 
 /datum/say_prefix/deadchat/process(datum/say_message/message, datum/speech_module_tree/say_tree)
-	. = message
 
 	say_tree.GetOutputByID(SPEECH_OUTPUT_DEADCHAT)?.process(message.Copy())
+	
+	qdel(message)

--- a/code/modules/speech/prefixes/deadchat.dm
+++ b/code/modules/speech/prefixes/deadchat.dm
@@ -4,7 +4,6 @@
 /datum/say_prefix/deadchat/is_compatible_with(datum/say_message/message, datum/speech_module_tree/say_tree)
 	return ismob(message.speaker) && inafterlife(message.speaker)
 
-/// Say prefix for """living""" beings in the afterlife bar/etc. This should not work anywhere else!
 /datum/say_prefix/deadchat/process(datum/say_message/message, datum/speech_module_tree/say_tree)
 	. = message
 

--- a/code/modules/speech/prefixes/deadchat.dm
+++ b/code/modules/speech/prefixes/deadchat.dm
@@ -7,7 +7,4 @@
 /datum/say_prefix/deadchat/process(datum/say_message/message, datum/speech_module_tree/say_tree)
 	. = message
 
-	if (!src.is_compatible_with(message, say_tree))
-		return
-
 	say_tree.GetOutputByID(SPEECH_OUTPUT_DEADCHAT)?.process(message.Copy())

--- a/code/modules/speech/prefixes/deadchat.dm
+++ b/code/modules/speech/prefixes/deadchat.dm
@@ -7,4 +7,7 @@
 /datum/say_prefix/deadchat/process(datum/say_message/message, datum/speech_module_tree/say_tree)
 	. = message
 
+	if (!src.is_compatible_with(message, say_tree))
+		return
+
 	say_tree.GetOutputByID(SPEECH_OUTPUT_DEADCHAT)?.process(message.Copy())

--- a/code/modules/speech/prefixes/deadchat.dm
+++ b/code/modules/speech/prefixes/deadchat.dm
@@ -1,12 +1,11 @@
 /datum/say_prefix/deadchat
 	id = ":d"
 
+/datum/say_prefix/deadchat/is_compatible_with(datum/say_message/message, datum/speech_module_tree/say_tree)
+	return ismob(message.speaker) && inafterlife(message.speaker)
+
 /// Say prefix for """living""" beings in the afterlife bar/etc. This should not work anywhere else!
 /datum/say_prefix/deadchat/process(datum/say_message/message, datum/speech_module_tree/say_tree)
 	. = message
 
-	var/mob/mob_speaker = message.speaker
-	if (!inafterlife(mob_speaker))
-		return
-	var/datum/say_message/deadchat_message = message.Copy()
-	say_tree.GetOutputByID(SPEECH_OUTPUT_DEADCHAT)?.process(deadchat_message)
+	say_tree.GetOutputByID(SPEECH_OUTPUT_DEADCHAT)?.process(message.Copy())

--- a/code/modules/speech/prefixes/deadchat.dm
+++ b/code/modules/speech/prefixes/deadchat.dm
@@ -1,0 +1,12 @@
+/datum/say_prefix/deadchat
+	id = ":d"
+
+/// Say prefix for """living""" beings in the afterlife bar/etc. This should not work anywhere else!
+/datum/say_prefix/deadchat/process(datum/say_message/message, datum/speech_module_tree/say_tree)
+	. = message
+
+	var/mob/mob_speaker = message.speaker
+	if (!inafterlife(mob_speaker))
+		return
+	var/datum/say_message/deadchat_message = message.Copy()
+	say_tree.GetOutputByID(SPEECH_OUTPUT_DEADCHAT)?.process(deadchat_message)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1789,6 +1789,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\speech\modules\outputs\spoken\subtle.dm"
 #include "code\modules\speech\prefixes\_say_prefix_parent.dm"
 #include "code\modules\speech\prefixes\ai_radio.dm"
+#include "code\modules\speech\prefixes\deadchat.dm"
 #include "code\modules\speech\prefixes\intercom.dm"
 #include "code\modules\speech\prefixes\left_hand.dm"
 #include "code\modules\speech\prefixes\radio.dm"


### PR DESCRIPTION
Adds a say prefix for ':d' functionality, restricted to the afterlife bar.