### PR TITLE
Override Say Channel Modifier Preference

### DIFF
--- a/code/modules/speech/core.dm
+++ b/code/modules/speech/core.dm
@@ -145,7 +145,6 @@ Contributing:
 Limitations To Later Code Out:
 - Currently tree can only support one instance of each module ID - this is not ideal for delimited listen and speech modules.
 - Delimited listen modules do not harmonise with associted global listen modules - two messages will be displayed.
-- The say channel `affected_by_modifiers` var cannot be overriden by modifers - this is an issue for admin modules.
 
 Cleanup:
 - Move say procs into this directory.

--- a/code/modules/speech/modules/modifiers/listen/_listen_modifier_parent.dm
+++ b/code/modules/speech/modules/modifiers/listen/_listen_modifier_parent.dm
@@ -4,3 +4,5 @@ ABSTRACT_TYPE(/datum/listen_module/modifier)
  */
 /datum/listen_module/modifier
 	id = "modifier_base"
+	/// Whether this modifier listen module should respect the say channel's `affected_by_modifiers` variable.
+	var/override_say_channel_modifier_preference = FALSE

--- a/code/modules/speech/modules/modifiers/listen/admin_hearing.dm
+++ b/code/modules/speech/modules/modifiers/listen/admin_hearing.dm
@@ -1,5 +1,6 @@
 /datum/listen_module/modifier/admin_hearing
 	id = LISTEN_MODIFIER_ADMIN_HEARING
+	override_say_channel_modifier_preference = TRUE
 
 /datum/listen_module/modifier/admin_hearing/process(datum/say_message/message)
 	. = message

--- a/code/modules/speech/modules/modifiers/speech/_speech_modifier_parent.dm
+++ b/code/modules/speech/modules/modifiers/speech/_speech_modifier_parent.dm
@@ -4,3 +4,5 @@ ABSTRACT_TYPE(/datum/speech_module/modifier)
  */
 /datum/speech_module/modifier
 	id = "modifier_base"
+	/// Whether this modifier speech module should respect the say channel's `affected_by_modifiers` variable.
+	var/override_say_channel_modifier_preference = FALSE


### PR DESCRIPTION
## About The PR:
Permits speech/listen modifiers with `override_say_channel_modifier_preference` set to override `affected_by_modifiers` on say channels. This permits admin modules to work irrespective of whether `affected_by_modifiers` is set on a channel.