### PR TITLE
Input Priority & Message Buffering

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -105,6 +105,7 @@
 #include "defines\speech_defines\channels.dm"
 #include "defines\speech_defines\languages.dm"
 #include "defines\speech_defines\modules.dm"
+#include "defines\speech_defines\priorities.dm"
 #include "defines\speech_defines\relays.dm"
 #include "defines\speech_defines\sayflags.dm"
 #include "defines\speech_defines\speech.dm"

--- a/_std/defines/component_defines/component_defines_special.dm
+++ b/_std/defines/component_defines/component_defines_special.dm
@@ -155,7 +155,7 @@
 #define COMSIG_SPEAKER_ORIGIN_UPDATED "speaker_origin_updated"
 /// When a listen module tree's listener origin is updated. (listen tree, old_listener_origin, new_listener_origin)
 #define COMSIG_LISTENER_ORIGIN_UPDATED "listener_origin_updated"
-/// Flush all message buffers.
+/// Flush all message buffers associated with the target datum.
 #define COMSIG_FLUSH_MESSAGE_BUFFER "flush_message_buffer"
 
 // ---- Client Signals ----

--- a/_std/defines/component_defines/component_defines_special.dm
+++ b/_std/defines/component_defines/component_defines_special.dm
@@ -155,6 +155,8 @@
 #define COMSIG_SPEAKER_ORIGIN_UPDATED "speaker_origin_updated"
 /// When a listen module tree's listener origin is updated. (listen tree, old_listener_origin, new_listener_origin)
 #define COMSIG_LISTENER_ORIGIN_UPDATED "listener_origin_updated"
+/// Flush all message buffers.
+#define COMSIG_FLUSH_MESSAGE_BUFFER "flush_message_buffer"
 
 // ---- Client Signals ----
 /// When a client logs into a mob. (client, mob)

--- a/_std/defines/speech_defines/priorities.dm
+++ b/_std/defines/speech_defines/priorities.dm
@@ -1,0 +1,24 @@
+//------------ Sayflags ------------//
+#define SAYFLAG_PRIORITY_DEFAULT 0
+#define SAYFLAG_PRIORITY_LOW -10
+#define SAYFLAG_PRIORITY_PROCESS_LAST -1000
+
+//------------ Speech Outputs ------------//
+#define SPEECH_OUTPUT_PRIORITY_HIGH 10
+#define SPEECH_OUTPUT_PRIORITY_DEFAULT 0
+
+//------------ Speech Modifiers ------------//
+#define SPEECH_MODIFIER_PRIORITY_PROCESS_FIRST 1000
+#define SPEECH_MODIFIER_PRIORITY_VERY_HIGH 100
+#define SPEECH_MODIFIER_PRIORITY_DEFAULT 0
+#define SPEECH_MODIFIER_PRIORITY_MUTANTRACES -5
+#define SPEECH_MODIFIER_PRIORITY_ACCENTS -10
+#define SPEECH_MODIFIER_PRIORITY_VERY_LOW -100
+
+//------------ Listen Inputs ------------//
+#define LISTEN_INPUT_PRIORITY_DEFAULT 0
+#define LISTEN_INPUT_PRIORITY_DISTORTED -20
+#define LISTEN_INPUT_PRIORITY_GLOBAL -10
+
+//------------ Listen Modifiers ------------//
+#define LISTEN_MODIFIER_PRIORITY_DEFAULT 0

--- a/_std/defines/speech_defines/relays.dm
+++ b/_std/defines/speech_defines/relays.dm
@@ -3,7 +3,8 @@
 /// Flags a message as having been retransmitted through a relay of the specified type.
 #define FORMAT_MESSAGE_FOR_RELAY(message, relay_flag) \
 	message.relay_flags |= relay_flag; \
-	message.flags &= ~SAYFLAG_SPOKEN_BY_PLAYER;
+	message.flags &= ~SAYFLAG_SPOKEN_BY_PLAYER; \
+	message.id = "\ref[message]";
 
 //------------ Relay Types ------------//
 #define SAY_RELAY_MICROPHONE (1 << 0)

--- a/code/modules/speech/core.dm
+++ b/code/modules/speech/core.dm
@@ -147,7 +147,6 @@ Contributing:
 
 Limitations To Later Code Out:
 - Currently tree can only support one instance of each module ID - this is not ideal for delimited listen and speech modules.
-- Delimited listen modules do not harmonise with associted global listen modules - two messages will be displayed.
 
 Cleanup:
 - Move say procs into this directory.
@@ -156,6 +155,7 @@ Cleanup:
 - `RETURN_TYPE` where necessary.
 
 Old Code To Remove:
+- Deprecate `boutput_relay_mob`. This also causes a bug with flocks.
 - `proc/speak`. `all_hearers` implementations may be good to look at too.
 - `say()` implementations that predate the rework.
 - Replace `COMSIG_MOB_SAY` with `COMSIG_ATOM_SAY`.
@@ -163,6 +163,7 @@ Old Code To Remove:
 
 Refactors:
 - Perhaps refactor `/mob/living/say_radio()` to be cleaner?
+- Perhaps prevent input modules stored on aux trees from instantiating.
 - Anything that uses `SPAN_NAME` could likely be moved onto the new system.
 - Some form of centralised preference manager for toggling inputs/outputs for types?
 	- `togglepersonaldeadchat`, `toggle_ghost_radio`, `toggle_ooc`, `toggle_looc`, etc.

--- a/code/modules/speech/message_modifiers/_message_modifier_parent.dm
+++ b/code/modules/speech/message_modifiers/_message_modifier_parent.dm
@@ -8,7 +8,7 @@ ABSTRACT_TYPE(/datum/message_modifier)
 	/// The sayflag associated with this message modifier; it *MUST* be unique.
 	var/sayflag = 0
 	/// How far up the message modifier list this modifier should go. High values get processed before low values.
-	var/priority = 0
+	var/priority = SAYFLAG_PRIORITY_DEFAULT
 
 /// Handle all processing that pertains to the say pipeline. Return `null` to prevent the message being processed further, or a `/datum/say_message` instance to continue.
 /datum/message_modifier/proc/process(datum/say_message/message)

--- a/code/modules/speech/message_modifiers/no_say_verb.dm
+++ b/code/modules/speech/message_modifiers/no_say_verb.dm
@@ -1,6 +1,6 @@
 /datum/message_modifier/postprocessing/no_say_verb
 	sayflag = SAYFLAG_NO_SAY_VERB
-	priority = -100
+	priority = SAYFLAG_PRIORITY_PROCESS_LAST
 
 /datum/message_modifier/postprocessing/no_say_verb/process(datum/say_message/message)
 	. = message

--- a/code/modules/speech/message_modifiers/quotation_marks.dm
+++ b/code/modules/speech/message_modifiers/quotation_marks.dm
@@ -1,6 +1,6 @@
 /datum/message_modifier/postprocessing/quotation_marks
 	sayflag = SAYFLAG_HAS_QUOTATION_MARKS
-	priority = -100
+	priority = SAYFLAG_PRIORITY_PROCESS_LAST
 
 /datum/message_modifier/postprocessing/quotation_marks/process(datum/say_message/message)
 	. = message

--- a/code/modules/speech/message_modifiers/singing.dm
+++ b/code/modules/speech/message_modifiers/singing.dm
@@ -21,7 +21,7 @@
 
 /datum/message_modifier/postprocessing/singing
 	sayflag = SAYFLAG_SINGING
-	priority = -10
+	priority = SAYFLAG_PRIORITY_LOW
 
 /datum/message_modifier/postprocessing/singing/process(datum/say_message/message)
 	. = message

--- a/code/modules/speech/modules/inputs/_input_module_parent.dm
+++ b/code/modules/speech/modules/inputs/_input_module_parent.dm
@@ -5,6 +5,7 @@ ABSTRACT_TYPE(/datum/listen_module/input)
  */
 /datum/listen_module/input
 	id = "input_base"
+	priority = LISTEN_INPUT_PRIORITY_DEFAULT
 	/// The channel ID that this listen module should listen on.
 	var/channel = "none"
 	/// The say channel datum that this module is currently listening on.

--- a/code/modules/speech/modules/inputs/flock.dm
+++ b/code/modules/speech/modules/inputs/flock.dm
@@ -24,9 +24,11 @@
 
 /datum/listen_module/input/distorted_flock
 	id = LISTEN_INPUT_FLOCK_DISTORTED
+	priority = LISTEN_INPUT_PRIORITY_DISTORTED
 	channel = SAY_CHANNEL_DISTORTED_FLOCK
 
 
 /datum/listen_module/input/global_flock
 	id = LISTEN_INPUT_FLOCK_GLOBAL
+	priority = LISTEN_INPUT_PRIORITY_GLOBAL
 	channel = SAY_CHANNEL_GLOBAL_FLOCK

--- a/code/modules/speech/modules/inputs/hivechat.dm
+++ b/code/modules/speech/modules/inputs/hivechat.dm
@@ -5,4 +5,5 @@
 
 /datum/listen_module/input/global_hivemind
 	id = LISTEN_INPUT_HIVECHAT_GLOBAL
+	priority = LISTEN_INPUT_PRIORITY_GLOBAL
 	channel = SAY_CHANNEL_GLOBAL_HIVEMIND

--- a/code/modules/speech/modules/inputs/looc.dm
+++ b/code/modules/speech/modules/inputs/looc.dm
@@ -9,4 +9,5 @@
 
 /datum/listen_module/input/looc/admin_global
 	id = LISTEN_INPUT_LOOC_ADMIN_GLOBAL
+	priority = LISTEN_INPUT_PRIORITY_GLOBAL
 	channel = SAY_CHANNEL_GLOBAL_LOOC

--- a/code/modules/speech/modules/inputs/radio.dm
+++ b/code/modules/speech/modules/inputs/radio.dm
@@ -5,6 +5,7 @@
 
 /datum/listen_module/input/distorted_radio
 	id = LISTEN_INPUT_RADIO_DISTORTED
+	priority = LISTEN_INPUT_PRIORITY_DISTORTED
 	channel = SAY_CHANNEL_GLOBAL_RADIO
 
 

--- a/code/modules/speech/modules/inputs/siliconchat.dm
+++ b/code/modules/speech/modules/inputs/siliconchat.dm
@@ -5,4 +5,5 @@
 
 /datum/listen_module/input/distorted_siliconchat
 	id = LISTEN_INPUT_SILICONCHAT_DISTORTED
+	priority = LISTEN_INPUT_PRIORITY_DISTORTED
 	channel = SAY_CHANNEL_SILICON

--- a/code/modules/speech/modules/inputs/thrallchat.dm
+++ b/code/modules/speech/modules/inputs/thrallchat.dm
@@ -5,4 +5,5 @@
 
 /datum/listen_module/input/global_thrall
 	id = LISTEN_INPUT_THRALLCHAT_GLOBAL
+	priority = LISTEN_INPUT_PRIORITY_GLOBAL
 	channel = SAY_CHANNEL_GLOBAL_THRALL

--- a/code/modules/speech/modules/modifiers/listen/_listen_modifier_parent.dm
+++ b/code/modules/speech/modules/modifiers/listen/_listen_modifier_parent.dm
@@ -4,5 +4,6 @@ ABSTRACT_TYPE(/datum/listen_module/modifier)
  */
 /datum/listen_module/modifier
 	id = "modifier_base"
+	priority = LISTEN_MODIFIER_PRIORITY_DEFAULT
 	/// Whether this modifier listen module should respect the say channel's `affected_by_modifiers` variable.
 	var/override_say_channel_modifier_preference = FALSE

--- a/code/modules/speech/modules/modifiers/listen/phone_formatting.dm
+++ b/code/modules/speech/modules/modifiers/listen/phone_formatting.dm
@@ -4,6 +4,7 @@
 /datum/listen_module/modifier/phone/process(datum/say_message/message)
 	// If this message has already been relayed by a phone, don't receive it.
 	if (!CAN_RELAY_MESSAGE(message, SAY_RELAY_PHONE))
+		qdel(message)
 		return
 
 	. = message

--- a/code/modules/speech/modules/modifiers/listen/radio_formatting.dm
+++ b/code/modules/speech/modules/modifiers/listen/radio_formatting.dm
@@ -4,6 +4,7 @@
 /datum/listen_module/modifier/radio/process(datum/say_message/message)
 	// If this message has already been relayed by a radio, don't receive it.
 	if (!CAN_RELAY_MESSAGE(message, SAY_RELAY_RADIO))
+		qdel(message)
 		return
 
 	. = message

--- a/code/modules/speech/modules/modifiers/speech/_speech_modifier_parent.dm
+++ b/code/modules/speech/modules/modifiers/speech/_speech_modifier_parent.dm
@@ -4,5 +4,6 @@ ABSTRACT_TYPE(/datum/speech_module/modifier)
  */
 /datum/speech_module/modifier
 	id = "modifier_base"
+	priority = SPEECH_MODIFIER_PRIORITY_DEFAULT
 	/// Whether this modifier speech module should respect the say channel's `affected_by_modifiers` variable.
 	var/override_say_channel_modifier_preference = FALSE

--- a/code/modules/speech/modules/modifiers/speech/accents.dm
+++ b/code/modules/speech/modules/modifiers/speech/accents.dm
@@ -1,7 +1,7 @@
 ABSTRACT_TYPE(/datum/speech_module/modifier/accent)
 /datum/speech_module/modifier/accent
 	id = "accent_base"
-	priority = -10
+	priority = SPEECH_MODIFIER_PRIORITY_ACCENTS
 
 
 // Dialects:

--- a/code/modules/speech/modules/modifiers/speech/bot.dm
+++ b/code/modules/speech/modules/modifiers/speech/bot.dm
@@ -1,6 +1,6 @@
 /datum/speech_module/modifier/bot
 	id = SPEECH_MODIFIER_BOT
-	priority = -100
+	priority = SPEECH_MODIFIER_PRIORITY_VERY_LOW
 
 /datum/speech_module/modifier/bot/process(datum/say_message/message)
 	. = message

--- a/code/modules/speech/modules/modifiers/speech/mob_modifiers.dm
+++ b/code/modules/speech/modules/modifiers/speech/mob_modifiers.dm
@@ -1,6 +1,6 @@
 /datum/speech_module/modifier/mob_modifiers
 	id = SPEECH_MODIFIER_MOB_MODIFIERS
-	priority = 100
+	priority = SPEECH_MODIFIER_PRIORITY_VERY_HIGH
 
 /datum/speech_module/modifier/mob_modifiers/process(datum/say_message/message)
 	. = message

--- a/code/modules/speech/modules/modifiers/speech/mutantraces/_mutantrace_modifier_parent.dm
+++ b/code/modules/speech/modules/modifiers/speech/mutantraces/_mutantrace_modifier_parent.dm
@@ -1,4 +1,4 @@
 ABSTRACT_TYPE(/datum/speech_module/modifier/mutantrace)
 /datum/speech_module/modifier/mutantrace
 	id = "mutantrace_base"
-	priority = -5
+	priority = SPEECH_MODIFIER_PRIORITY_MUTANTRACES

--- a/code/modules/speech/modules/modifiers/speech/mute.dm
+++ b/code/modules/speech/modules/modifiers/speech/mute.dm
@@ -1,6 +1,6 @@
 /datum/speech_module/modifier/mute
 	id = SPEECH_MODIFIER_MUTE
-	priority = 1000
+	priority = SPEECH_MODIFIER_PRIORITY_PROCESS_FIRST
 
 /datum/speech_module/modifier/mute/process(datum/say_message/message)
 	if (message.output_module_channel != SAY_CHANNEL_OUTLOUD)

--- a/code/modules/speech/modules/modifiers/speech/muzzle.dm
+++ b/code/modules/speech/modules/modifiers/speech/muzzle.dm
@@ -1,6 +1,6 @@
 /datum/speech_module/modifier/muzzle
 	id = SPEECH_MODIFIER_MUZZLE
-	priority = 1000
+	priority = SPEECH_MODIFIER_PRIORITY_PROCESS_FIRST
 
 /datum/speech_module/modifier/muzzle/process(datum/say_message/message)
 	if (message.output_module_channel != SAY_CHANNEL_OUTLOUD)

--- a/code/modules/speech/modules/modifiers/speech/revenant.dm
+++ b/code/modules/speech/modules/modifiers/speech/revenant.dm
@@ -1,6 +1,6 @@
 /datum/speech_module/modifier/revenant
 	id = SPEECH_MODIFIER_REVENANT
-	priority = 1000
+	priority = SPEECH_MODIFIER_PRIORITY_PROCESS_FIRST
 
 /datum/speech_module/modifier/revenant/process(datum/say_message/message)
 	if (message.output_module_channel != SAY_CHANNEL_OUTLOUD)

--- a/code/modules/speech/modules/outputs/_output_module_parent.dm
+++ b/code/modules/speech/modules/outputs/_output_module_parent.dm
@@ -5,6 +5,7 @@ ABSTRACT_TYPE(/datum/speech_module/output)
  */
 /datum/speech_module/output
 	id = "output_base"
+	priority = SPEECH_OUTPUT_PRIORITY_DEFAULT
 	/// The channel ID that this output module should pass say messages to.
 	var/channel = "none"
 	/// The say channel datum that this module should pass say messages to.

--- a/code/modules/speech/modules/outputs/deadchat.dm
+++ b/code/modules/speech/modules/outputs/deadchat.dm
@@ -1,6 +1,6 @@
 /datum/speech_module/output/deadchat
 	id = SPEECH_OUTPUT_DEADCHAT
-	priority = 0
+	priority = SPEECH_OUTPUT_PRIORITY_DEFAULT
 	channel = SAY_CHANNEL_DEAD
 	var/role
 
@@ -62,19 +62,19 @@
 
 /datum/speech_module/output/deadchat/ghost
 	id = SPEECH_OUTPUT_DEADCHAT_GHOST
-	priority = 10
+	priority = SPEECH_OUTPUT_PRIORITY_HIGH
 	role = "Ghost"
 
 
 /datum/speech_module/output/deadchat/poltergeist
 	id = SPEECH_OUTPUT_DEADCHAT_POLTERGEIST
-	priority = 10
+	priority = SPEECH_OUTPUT_PRIORITY_HIGH
 	role = "Poltergeist"
 
 
 /datum/speech_module/output/deadchat/wraith
 	id = SPEECH_OUTPUT_DEADCHAT_WRAITH
-	priority = 10
+	priority = SPEECH_OUTPUT_PRIORITY_HIGH
 	role = "Wraith"
 
 

--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -46,6 +46,10 @@ var/regex/forbidden_character_regex = regex(@"[\u2028\u202a\u202b\u202c\u202d\u2
 	var/real_ident = null
 
 	// Message Information Variables:
+	/// The non-unique ID of this message. A listener may only hear one message of a specific ID at any time.
+	var/id = ""
+	/// The datum that should act as a signal recipient for every copy of this message.
+	var/datum/signal_recipient
 	/// The original contents of this message, uneditied, unsanitised.
 	var/original_content = ""
 	/// Message flags. See `_std/defines/speech_defines/sayflags.dm`.
@@ -111,6 +115,7 @@ var/regex/forbidden_character_regex = regex(@"[\u2028\u202a\u202b\u202c\u202d\u2
 	src.speaker = speaker.say_tree.speaker_parent
 	src.original_speaker = speaker.say_tree.speaker_parent
 	src.message_origin = speaker.say_tree.speaker_origin
+	src.id = "\ref[src]"
 	src.flags |= flags
 	src.atom_listeners_override = atom_listeners_override
 	src.maptext_css_values = list()

--- a/code/modules/speech/trees/auxiliary_listen_module_tree.dm
+++ b/code/modules/speech/trees/auxiliary_listen_module_tree.dm
@@ -17,6 +17,9 @@
 /datum/listen_module_tree/auxiliary/process()
 	return
 
+/datum/listen_module_tree/auxiliary/flush_message_buffer()
+	return
+
 /datum/listen_module_tree/auxiliary/AddInput(input_id)
 	src.target_listen_tree?.AddInput(input_id)
 	. = ..()

--- a/code/modules/speech/trees/listen_module_tree.dm
+++ b/code/modules/speech/trees/listen_module_tree.dm
@@ -12,7 +12,7 @@
 	var/list/atom/secondary_parents
 	/// A list of all auxiliary listen module trees with this listen module tree registered as a target.
 	var/list/datum/listen_module_tree/auxiliary/auxiliary_trees
-	/// A temporary buffer of all received messages that are to be processed when the buffer is flushed.
+	/// A temporary buffer of all received messages that are to be outputted to the parent when the buffer is flushed.
 	var/list/datum/say_message/message_buffer
 	/// An associative list of all signal recipients that may cause the message buffer to flush.
 	var/list/datum/signal_recipients

--- a/code/modules/speech/trees/listen_module_tree.dm
+++ b/code/modules/speech/trees/listen_module_tree.dm
@@ -12,6 +12,10 @@
 	var/list/atom/secondary_parents
 	/// A list of all auxiliary listen module trees with this listen module tree registered as a target.
 	var/list/datum/listen_module_tree/auxiliary/auxiliary_trees
+	/// A temporary buffer of all received messages that are to be processed when the buffer is flushed.
+	var/list/datum/say_message/message_buffer
+	/// An associative list of all signal recipients that may cause the message buffer to flush.
+	var/list/datum/signal_recipients
 
 	/// An associative list of input listen module subscription counts, indexed by the module ID.
 	var/list/input_module_ids_with_subcount
@@ -41,6 +45,8 @@
 	src.listener_origin = parent
 	src.secondary_parents = list()
 	src.auxiliary_trees = list()
+	src.message_buffer = list()
+	src.signal_recipients = list()
 
 	src.input_module_ids_with_subcount = list()
 	src.input_modules_by_id = list()
@@ -60,6 +66,11 @@
 		src.AddKnownLanguage(language_id)
 
 /datum/listen_module_tree/disposing()
+	for (var/datum/signal_recipient as anything in src.signal_recipients)
+		src.UnregisterSignal(signal_recipient, COMSIG_FLUSH_MESSAGE_BUFFER)
+
+	src.signal_recipients = null
+
 	for (var/datum/listen_module_tree/auxiliary/auxiliary_tree as anything in src.auxiliary_trees)
 		auxiliary_tree.update_target_listen_tree(null)
 
@@ -80,6 +91,8 @@
 		src.listener_parent = null
 
 	src.secondary_parents = null
+	src.message_buffer = null
+	src.signal_recipients = null
 	src.input_modules_by_id = null
 	src.listen_modifiers_by_id = null
 	src.input_modules_by_channel = null
@@ -114,8 +127,27 @@
 			if (QDELETED(message))
 				return
 
-	/// Pass to the listener atom.
-	src.listener_parent.hear(message)
+	// If a message of this ID already exists in the buffer, do not buffer the new message unless it was heard by a higher priority module.
+	if (src.message_buffer[message.id] && (message.received_module.priority <= src.message_buffer[message.id].received_module.priority))
+		return
+
+	src.message_buffer[message.id] = message
+
+	if (!src.signal_recipients[message.signal_recipient])
+		src.signal_recipients[message.signal_recipient] = TRUE
+		src.RegisterSignal(message.signal_recipient, COMSIG_FLUSH_MESSAGE_BUFFER, PROC_REF(flush_message_buffer))
+
+/// Outputs all messages stored in the message buffer to the listener parent.
+/datum/listen_module_tree/proc/flush_message_buffer()
+	for (var/id in src.message_buffer)
+		var/datum/say_message/message = src.message_buffer[id]
+		src.listener_parent.hear(message)
+
+		if (src.signal_recipients[message.signal_recipient])
+			src.UnregisterSignal(message.signal_recipient, COMSIG_FLUSH_MESSAGE_BUFFER)
+			src.signal_recipients -= message.signal_recipient
+
+	src.message_buffer = list()
 
 /// Migrates this listen module tree to a new speaker parent and origin.
 /datum/listen_module_tree/proc/migrate_listen_tree(atom/new_parent, atom/new_origin, preserve_old_reference = FALSE)

--- a/code/modules/speech/trees/speech_module_tree.dm
+++ b/code/modules/speech/trees/speech_module_tree.dm
@@ -126,6 +126,8 @@
 	if (message.flags & SAYFLAG_DO_NOT_OUTPUT)
 		return
 
+	message.signal_recipient = message
+
 	// Attempt to use the highest priority module as an output, defaulting to the next highest priority on failure.
 	for (var/datum/speech_module/output/output_module as anything in output_modules)
 		if (!CAN_PASS_MESSAGE_TO_SAY_CHANNEL(output_module.say_channel, message))
@@ -143,6 +145,8 @@
 			module_message.process_speech_bubble()
 
 		break
+
+	SEND_SIGNAL(message, COMSIG_FLUSH_MESSAGE_BUFFER)
 
 /// Migrates this speech module tree to a new speaker parent and origin.
 /datum/speech_module_tree/proc/migrate_speech_tree(atom/new_parent, atom/new_origin, preserve_old_reference = FALSE)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -33,6 +33,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // BEGIN_INCLUDE
+#include "_std\defines\speech_defines\priorities.dm"
 #include "code\area.dm"
 #include "code\atom.dm"
 #include "code\client.dm"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -33,7 +33,6 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // BEGIN_INCLUDE
-#include "_std\defines\speech_defines\priorities.dm"
 #include "code\area.dm"
 #include "code\atom.dm"
 #include "code\client.dm"


### PR DESCRIPTION
## About The PR:
Listen module trees will now store received messages in a buffer, storing one message for each unique message ID. If two messages with the same ID are received, then the message received by the input with the highest priority will be stored.

The message buffer is flushed through the `COMSIG_FLUSH_MESSAGE_BUFFER` signal; this signal is sent to a common datum shared by all messages of the same origin. Currently the original uncopied message datum is used as the message signal recipient.

This system has the desired effects of both permitting inputs to implement priority in a meaningful way and to prevent duplicate messages from being received by two input modules while preserving duplicate messages being received by multiple speakers (see loudspeakers, many intercoms, etc).

Additionally implements priority defines.