### PR TITLE
Modules Trees May Now Possess Multiple Bundled Modules

### DIFF
--- a/_std/defines/speech_defines/speech.dm
+++ b/_std/defines/speech_defines/speech.dm
@@ -1,3 +1,12 @@
+//------------- WRAPPERS -------------//
+/// A wrapper for _AddOutput that permits the usage of named arguments.
+#define AddOutput(output_id, arguments...) _AddOutput(output_id, list(##arguments))
+/// A wrapper for _AddInput that permits the usage of named arguments.
+#define AddInput(input_id, arguments...) _AddInput(input_id, list(##arguments))
+/// A wrapper for _AddModifier that permits the usage of named arguments. This caters to both speech and listen trees.
+#define AddModifier(modifier_id, arguments...) _AddModifier(modifier_id, list(##arguments))
+
+
 //------------- COOLDOWNS -------------//
 /// The minimum time between voice sound effects for a single atom. Measured in tenths of a second.
 #define VOICE_SOUND_COOLDOWN 8

--- a/_std/defines/speech_defines/speech.dm
+++ b/_std/defines/speech_defines/speech.dm
@@ -1,10 +1,12 @@
 //------------- WRAPPERS -------------//
-/// A wrapper for _AddOutput that permits the usage of named arguments.
-#define AddOutput(output_id, arguments...) _AddOutput(output_id, list(##arguments))
-/// A wrapper for _AddInput that permits the usage of named arguments.
-#define AddInput(input_id, arguments...) _AddInput(input_id, list(##arguments))
-/// A wrapper for _AddModifier that permits the usage of named arguments. This caters to both speech and listen trees.
-#define AddModifier(modifier_id, arguments...) _AddModifier(modifier_id, list(##arguments))
+/// A wrapper for _AddSpeechOutput that permits the usage of named arguments.
+#define AddSpeechOutput(output_id, arguments...) _AddSpeechOutput(output_id, list(##arguments))
+/// A wrapper for _AddSpeechModifier that permits the usage of named arguments.
+#define AddSpeechModifier(modifier_id, arguments...) _AddSpeechModifier(modifier_id, list(##arguments))
+/// A wrapper for _AddListenInput that permits the usage of named arguments.
+#define AddListenInput(input_id, arguments...) _AddListenInput(input_id, list(##arguments))
+/// A wrapper for _AddListenModifier that permits the usage of named arguments.
+#define AddListenModifier(modifier_id, arguments...) _AddListenModifier(modifier_id, list(##arguments))
 
 
 //------------- COOLDOWNS -------------//

--- a/code/WorkInProgress/AphsStuff.dm
+++ b/code/WorkInProgress/AphsStuff.dm
@@ -148,7 +148,7 @@
 
 		return
 
-	say(message, flags, message_params, atom_listeners_override)
+	say(message, flags, list/message_params, list/atom/atom_listeners_override)
 		if (!src.on)
 			return
 

--- a/code/datums/abilities/revenant.dm
+++ b/code/datums/abilities/revenant.dm
@@ -87,7 +87,7 @@
 		owner.set_body_icon_dirty()
 		hud = new hud_path(owner)
 		owner.attach_hud(hud)
-		owner.ensure_say_tree().AddModifier(SPEECH_MODIFIER_REVENANT)
+		owner.ensure_say_tree().AddSpeechModifier(SPEECH_MODIFIER_REVENANT)
 
 		animate_levitate(owner)
 
@@ -103,7 +103,7 @@
 			REMOVE_ATOM_PROPERTY(owner, PROP_MOB_STUN_RESIST_MAX, "revenant")
 			REMOVE_MOVEMENT_MODIFIER(owner, /datum/movement_modifier/revenant, src.type)
 			owner.detach_hud(hud)
-			owner.ensure_say_tree().RemoveModifier(SPEECH_MODIFIER_REVENANT)
+			owner.ensure_say_tree().RemoveSpeechModifier(SPEECH_MODIFIER_REVENANT)
 		..()
 
 	proc/ghoulTouch(var/mob/living/carbon/human/poorSob, var/def_zone)

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -331,29 +331,13 @@ proc/get_default_flock()
 		aH = T.abilityHolder
 		aH?.updateTiles(tiles_owned)
 
-/datum/flock/proc/update_speech_channels_of_flockmob(mob/M, subchannel = "\ref[src]")
-	var/datum/speech_module/output/bundled/flock_say/output = M.ensure_say_tree().GetOutputByID(SPEECH_OUTPUT_FLOCK)
-	output.subchannel = subchannel
-	output.flock = src
-
-/datum/flock/proc/update_listen_channels_of_flockmob(mob/M, subchannel = "\ref[src]")
-	var/datum/listen_module/input/bundled/flock/input = M.ensure_listen_tree().GetInputByID(LISTEN_INPUT_FLOCK)
-	input.ChangeSubchannel(subchannel)
-
-/datum/flock/proc/update_speech_channels_of_flockstructure(atom/A, subchannel = "\ref[src]")
-	var/datum/speech_module/output/bundled/flock_say/output = A.ensure_say_tree().GetOutputByID(SPEECH_OUTPUT_FLOCK_SYSTEM)
-	output.subchannel = subchannel
-	output.flock = src
-
 /datum/flock/proc/registerFlockmind(mob/living/intangible/flock/flockmind/F)
 	if(!F)
 		return
 
 	src.flockmind = F
-	src.update_speech_channels_of_flockmob(src.flockmind)
-
-	var/datum/listen_module/input/bundled/flockmind/input = src.flockmind.ensure_listen_tree().GetInputByID(LISTEN_INPUT_FLOCKMIND)
-	input.ChangeSubchannel("\ref[src]")
+	src.flockmind.ensure_say_tree().AddOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]", flock = src)
+	src.flockmind.ensure_listen_tree().AddInput(LISTEN_INPUT_FLOCKMIND, subchannel = "\ref[src]")
 
 //since flocktraces need to be given their flock in New this is useful for debug
 /datum/flock/proc/spawnTrace()
@@ -365,8 +349,8 @@ proc/get_default_flock()
 		return
 	src.traces |= T
 	src.update_computes(TRUE)
-	src.update_speech_channels_of_flockmob(T)
-	src.update_listen_channels_of_flockmob(T)
+	T.ensure_say_tree().AddOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]", flock = src)
+	T.ensure_listen_tree().AddInput(LISTEN_INPUT_FLOCK, subchannel = "\ref[src]")
 
 /datum/flock/proc/removeTrace(mob/living/intangible/flock/trace/T)
 	if(!T)
@@ -375,8 +359,8 @@ proc/get_default_flock()
 	src.active_names -= T.real_name
 	hideAnnotations(T)
 	src.update_computes(TRUE)
-	src.update_speech_channels_of_flockmob(T, null)
-	src.update_listen_channels_of_flockmob(T, null)
+	T.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]")
+	T.ensure_listen_tree().RemoveInput(LISTEN_INPUT_FLOCK, subchannel = "\ref[src]")
 
 /datum/flock/proc/ping(var/atom/target, var/mob/living/intangible/flock/pinger)
 	//awful typecheck because turfs and movables have vis_contents defined seperately because god hates us
@@ -565,7 +549,7 @@ proc/get_default_flock()
 			src.total_compute += comp_provided
 		src.update_computes()
 
-	src.update_speech_channels_of_flockmob(D)
+	D.ensure_say_tree().AddOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]", flock = src)
 
 /datum/flock/proc/removeDrone(mob/living/critter/flock/D)
 	if(!isflockmob(D))
@@ -585,9 +569,9 @@ proc/get_default_flock()
 		if (comp_provided > 0)
 			src.total_compute -= comp_provided
 		src.update_computes()
-	D.flock = null
 
-	src.update_speech_channels_of_flockmob(D, null)
+	D.flock = null
+	D.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]")
 
 // TRACES
 
@@ -626,7 +610,7 @@ proc/get_default_flock()
 			src.total_compute += comp_provided
 		src.update_computes()
 
-	src.update_speech_channels_of_flockstructure(S)
+	S.ensure_say_tree().AddOutput(SPEECH_OUTPUT_FLOCK_SYSTEM, subchannel = "\ref[src]", flock = src)
 
 /datum/flock/proc/removeStructure(obj/flock_structure/S)
 	if(!isflockstructure(S))
@@ -643,7 +627,7 @@ proc/get_default_flock()
 			src.total_compute -= comp_provided
 		src.update_computes()
 
-	src.update_speech_channels_of_flockstructure(S, null)
+	S.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_FLOCK_SYSTEM, subchannel = "\ref[src]")
 
 /datum/flock/proc/getComplexDroneCount()
 	if (!src.units)

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -336,8 +336,8 @@ proc/get_default_flock()
 		return
 
 	src.flockmind = F
-	src.flockmind.ensure_say_tree().AddOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]", flock = src)
-	src.flockmind.ensure_listen_tree().AddInput(LISTEN_INPUT_FLOCKMIND, subchannel = "\ref[src]")
+	src.flockmind.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]", flock = src)
+	src.flockmind.ensure_listen_tree().AddListenInput(LISTEN_INPUT_FLOCKMIND, subchannel = "\ref[src]")
 
 //since flocktraces need to be given their flock in New this is useful for debug
 /datum/flock/proc/spawnTrace()
@@ -349,8 +349,8 @@ proc/get_default_flock()
 		return
 	src.traces |= T
 	src.update_computes(TRUE)
-	T.ensure_say_tree().AddOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]", flock = src)
-	T.ensure_listen_tree().AddInput(LISTEN_INPUT_FLOCK, subchannel = "\ref[src]")
+	T.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]", flock = src)
+	T.ensure_listen_tree().AddListenInput(LISTEN_INPUT_FLOCK, subchannel = "\ref[src]")
 
 /datum/flock/proc/removeTrace(mob/living/intangible/flock/trace/T)
 	if(!T)
@@ -359,8 +359,8 @@ proc/get_default_flock()
 	src.active_names -= T.real_name
 	hideAnnotations(T)
 	src.update_computes(TRUE)
-	T.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]")
-	T.ensure_listen_tree().RemoveInput(LISTEN_INPUT_FLOCK, subchannel = "\ref[src]")
+	T.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]")
+	T.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_FLOCK, subchannel = "\ref[src]")
 
 /datum/flock/proc/ping(var/atom/target, var/mob/living/intangible/flock/pinger)
 	//awful typecheck because turfs and movables have vis_contents defined seperately because god hates us
@@ -549,7 +549,7 @@ proc/get_default_flock()
 			src.total_compute += comp_provided
 		src.update_computes()
 
-	D.ensure_say_tree().AddOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]", flock = src)
+	D.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]", flock = src)
 
 /datum/flock/proc/removeDrone(mob/living/critter/flock/D)
 	if(!isflockmob(D))
@@ -571,7 +571,7 @@ proc/get_default_flock()
 		src.update_computes()
 
 	D.flock = null
-	D.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]")
+	D.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_FLOCK, subchannel = "\ref[src]")
 
 // TRACES
 
@@ -610,7 +610,7 @@ proc/get_default_flock()
 			src.total_compute += comp_provided
 		src.update_computes()
 
-	S.ensure_say_tree().AddOutput(SPEECH_OUTPUT_FLOCK_SYSTEM, subchannel = "\ref[src]", flock = src)
+	S.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_FLOCK_SYSTEM, subchannel = "\ref[src]", flock = src)
 
 /datum/flock/proc/removeStructure(obj/flock_structure/S)
 	if(!isflockstructure(S))
@@ -627,7 +627,7 @@ proc/get_default_flock()
 			src.total_compute -= comp_provided
 		src.update_computes()
 
-	S.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_FLOCK_SYSTEM, subchannel = "\ref[src]")
+	S.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_FLOCK_SYSTEM, subchannel = "\ref[src]")
 
 /datum/flock/proc/getComplexDroneCount()
 	if (!src.units)

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -276,7 +276,7 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			M.say_language = src.override_language
 
 		if (src.mutantrace_speech_modifier)
-			M.ensure_say_tree().AddModifier(src.mutantrace_speech_modifier)
+			M.ensure_say_tree().AddSpeechModifier(src.mutantrace_speech_modifier)
 
 		M.ensure_listen_tree()
 		for (var/language_id in src.understood_languages)
@@ -359,7 +359,7 @@ ABSTRACT_TYPE(/datum/mutantrace)
 				src.mob.say_language = initial(src.mob.say_language)
 
 			if (src.mutantrace_speech_modifier)
-				src.mob.ensure_say_tree().RemoveModifier(src.mutantrace_speech_modifier)
+				src.mob.ensure_say_tree().RemoveSpeechModifier(src.mutantrace_speech_modifier)
 
 			src.mob.ensure_listen_tree()
 			for (var/language_id in src.understood_languages)
@@ -2054,8 +2054,8 @@ TYPEINFO(/datum/mutantrace/kudzu)
 				H.add_stam_mod_max("kudzu", -100)
 				APPLY_ATOM_PROPERTY(H, PROP_MOB_STAMINA_REGEN_BONUS, "kudzu", -5)
 				H.bioHolder.AddEffect("xray", power = 2, magical=1)
-				H.ensure_say_tree().AddOutput(SPEECH_OUTPUT_KUDZUCHAT)
-				H.ensure_listen_tree().AddInput(LISTEN_INPUT_KUDZUCHAT)
+				H.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_KUDZUCHAT)
+				H.ensure_listen_tree().AddListenInput(LISTEN_INPUT_KUDZUCHAT)
 
 				if (istype(H.abilityHolder, /datum/abilityHolder/composite))
 					var/datum/abilityHolder/composite/ch = H.abilityHolder
@@ -2067,8 +2067,8 @@ TYPEINFO(/datum/mutantrace/kudzu)
 			H.remove_stam_mod_max("kudzu")
 			REMOVE_ATOM_PROPERTY(H, PROP_MOB_STAMINA_REGEN_BONUS, "kudzu")
 
-			H.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_KUDZUCHAT)
-			H.ensure_listen_tree().RemoveInput(LISTEN_INPUT_KUDZUCHAT)
+			H.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_KUDZUCHAT)
+			H.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_KUDZUCHAT)
 
 		return ..()
 /* Commented out as this bypasses restricted Z checks. We will just lazily give them xray genes instead

--- a/code/datums/traits_disused.dm
+++ b/code/datums/traits_disused.dm
@@ -70,14 +70,14 @@
 	unselectable = 1
 
 	onAdd(mob/M)
-		M.ensure_say_tree().AddOutput(SPEECH_OUTPUT_SILICONCHAT)
-		M.ensure_listen_tree().AddInput(LISTEN_INPUT_SILICONCHAT)
+		M.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_SILICONCHAT)
+		M.ensure_listen_tree().AddListenInput(LISTEN_INPUT_SILICONCHAT)
 		M.listen_tree.AddKnownLanguage(LANGUAGE_SILICON)
 		M.listen_tree.AddKnownLanguage(LANGUAGE_BINARY)
 
 	onRemove(mob/M)
-		M.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_SILICONCHAT)
-		M.ensure_listen_tree().RemoveInput(LISTEN_INPUT_SILICONCHAT)
+		M.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_SILICONCHAT)
+		M.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_SILICONCHAT)
 		M.listen_tree.RemoveKnownLanguage(LANGUAGE_SILICON)
 		M.listen_tree.RemoveKnownLanguage(LANGUAGE_BINARY)
 

--- a/code/mob/dead.dm
+++ b/code/mob/dead.dm
@@ -36,11 +36,11 @@
 	. = ..()
 
 	src.ensure_listen_tree()
-	var/datum/listen_module/global_radio = src.listen_tree.AddInput(LISTEN_INPUT_RADIO_GLOBAL)
+	var/datum/listen_module/global_radio = src.listen_tree.AddListenInput(LISTEN_INPUT_RADIO_GLOBAL)
 	if (!src.client.mute_ghost_radio && !global_radio)
-		src.listen_tree.AddInput(LISTEN_INPUT_RADIO_GLOBAL)
+		src.listen_tree.AddListenInput(LISTEN_INPUT_RADIO_GLOBAL)
 	else if (src.client.mute_ghost_radio && global_radio)
-		src.listen_tree.RemoveInput(LISTEN_INPUT_RADIO_GLOBAL)
+		src.listen_tree.RemoveListenInput(LISTEN_INPUT_RADIO_GLOBAL)
 
 	if(client?.holder?.ghost_interaction)
 		setalive(src)

--- a/code/mob/dead/mentor_mouse_observer.dm
+++ b/code/mob/dead/mentor_mouse_observer.dm
@@ -116,5 +116,5 @@
 		if(!get_turf(src))
 			src.my_mouse.gib()
 		src.my_mouse = null
-		src.target.ensure_listen_tree().RemoveInput(LISTEN_INPUT_MENTOR_MOUSE)
+		src.target.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_MENTOR_MOUSE)
 		qdel(src)

--- a/code/mob/living/carbon/human/test.dm
+++ b/code/mob/living/carbon/human/test.dm
@@ -9,7 +9,7 @@
 		src.AddComponent(/datum/component/health_maptext)
 
 
-	say(message, flags, message_params, atom_listeners_override)
+	say(message, flags, list/message_params, list/atom/atom_listeners_override)
 		if(!shutup)
 			. = ..()
 

--- a/code/mob/living/carbon/human/virtual.dm
+++ b/code/mob/living/carbon/human/virtual.dm
@@ -19,8 +19,8 @@
 		sound_snap = 'sound/voice/virtual_snap.ogg'
 		sound_fingersnap = 'sound/voice/virtual_snap.ogg'
 		if (!is_ghost)
-			src.ensure_say_tree().AddOutput(SPEECH_OUTPUT_SPOKEN)
-			src.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_DEADCHAT)
+			src.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_SPOKEN)
+			src.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_DEADCHAT)
 			src.default_speech_output_channel = SAY_CHANNEL_OUTLOUD
 		SPAWN(0)
 			src.set_mutantrace(/datum/mutantrace/virtual)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -65,8 +65,9 @@
 			controller = new/mob/living/intangible/flock/trace(src, src.flock)
 			src.is_npc = FALSE
 		else
-			emote("beep")
-			src.say(pick_string("flockmind.txt", "flockdrone_created"))
+			SPAWN(1)
+				emote("beep")
+				src.say(pick_string("flockmind.txt", "flockdrone_created"))
 		if (src.flock) //can't do flock?.stats due to http://www.byond.com/forum/post/2841585
 			src.flock.stats.drones_made++
 	APPLY_ATOM_PROPERTY(src, PROP_MOB_EXAMINE_ALL_NAMES, src)

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -21,7 +21,7 @@ TYPEINFO(/mob/living/critter/flock)
 	start_listen_modifiers = null
 	start_listen_inputs = null
 	start_speech_modifiers = null
-	start_speech_outputs = list(SPEECH_OUTPUT_FLOCK)
+	start_speech_outputs = null
 	default_speech_output_channel = SAY_CHANNEL_FLOCK
 	start_listen_languages = list(LANGUAGE_ENGLISH, LANGUAGE_FEATHER)
 	say_language = LANGUAGE_FEATHER
@@ -68,7 +68,6 @@ TYPEINFO(/mob/living/critter/flock)
 
 /mob/living/critter/flock/New(var/atom/L, var/datum/flock/F=null)
 	src.flock = F || get_default_flock()
-	src.flock.update_speech_channels_of_flockmob(src)
 
 	..()
 	remove_lifeprocess(/datum/lifeprocess/radiation)

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -3947,7 +3947,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		boutput(src, "<span style='color:red; font-size:1.5em'><b>You are now in someone's pocket, can talk to [him_or_her(M)], and click on [his_or_her(M)] screen to ping in the place where you're ctrl+clicking. This is a feature meant for teaching and helping players. Do not abuse it by using it to just chat with your friends!</b></span>")
 		logTheThing(LOG_ADMIN, src, "jumps into [constructTarget(M, "admin")]'s pocket as a mentor mouse at [log_loc(M)].")
 		var/mob/dead/target_observer/mentor_mouse_observer/obs = new(M, src.is_admin)
-		M.ensure_listen_tree().AddInput(LISTEN_INPUT_MENTOR_MOUSE)
+		M.ensure_listen_tree().AddListenInput(LISTEN_INPUT_MENTOR_MOUSE)
 		obs.set_observe_target(M)
 		obs.my_mouse = src
 		src.set_loc(obs)

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -15,9 +15,9 @@
 	var/datum/tutorial_base/regional/flock/tutorial = null
 
 	start_listen_modifiers = null
-	start_listen_inputs = list(LISTEN_INPUT_EARS, LISTEN_INPUT_FLOCKMIND, LISTEN_INPUT_RADIO_DISTORTED, LISTEN_INPUT_SILICONCHAT_DISTORTED, LISTEN_INPUT_GHOSTLY_WHISPER)
+	start_listen_inputs = list(LISTEN_INPUT_EARS, LISTEN_INPUT_RADIO_DISTORTED, LISTEN_INPUT_SILICONCHAT_DISTORTED, LISTEN_INPUT_GHOSTLY_WHISPER)
 	start_speech_modifiers = null
-	start_speech_outputs = list(SPEECH_OUTPUT_FLOCK, SPEECH_OUTPUT_SPOKEN_FLOCKMIND, SPEECH_OUTPUT_EQUIPPED)
+	start_speech_outputs = list(SPEECH_OUTPUT_SPOKEN_FLOCKMIND, SPEECH_OUTPUT_EQUIPPED)
 	default_speech_output_channel = SAY_CHANNEL_FLOCK
 	start_listen_languages = list(LANGUAGE_ALL)
 	say_language = LANGUAGE_FEATHER

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -11,9 +11,9 @@
 	compute = -FLOCKTRACE_COMPUTE_COST //it is expensive to run more threads
 
 	start_listen_modifiers = null
-	start_listen_inputs = list(LISTEN_INPUT_EARS, LISTEN_INPUT_FLOCK, LISTEN_INPUT_RADIO_DISTORTED, LISTEN_INPUT_SILICONCHAT_DISTORTED, LISTEN_INPUT_GHOSTLY_WHISPER)
+	start_listen_inputs = list(LISTEN_INPUT_EARS, LISTEN_INPUT_RADIO_DISTORTED, LISTEN_INPUT_SILICONCHAT_DISTORTED, LISTEN_INPUT_GHOSTLY_WHISPER)
 	start_speech_modifiers = null
-	start_speech_outputs = list(SPEECH_OUTPUT_FLOCK)
+	start_speech_outputs = null
 	default_speech_output_channel = SAY_CHANNEL_FLOCK
 	start_listen_languages = list(LANGUAGE_ALL)
 	say_language = LANGUAGE_FEATHER

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -174,8 +174,8 @@
 	if (ghost_spawned || newmob.ghost_spawned)
 		newmob.ghost_spawned = TRUE
 
-		newmob.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_SILICONCHAT)
-		newmob.ensure_listen_tree().RemoveInput(LISTEN_INPUT_SILICONCHAT)
+		newmob.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_SILICONCHAT)
+		newmob.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_SILICONCHAT)
 
 		if(!istype(newmob, /mob/living/critter/small_animal/mouse/weak/mentor))
 			newmob.name_prefix("ethereal")
@@ -624,8 +624,8 @@ var/list/antag_respawn_critter_types =  list(/mob/living/critter/small_animal/fl
 	var/mob/living/carbon/human/newbody = new(target_turf, null, src.client.preferences, TRUE)
 	newbody.real_name = src.real_name
 	newbody.ghost = src //preserve your original ghost
-	newbody.ensure_say_tree().AddOutput(SPEECH_OUTPUT_DEADCHAT)
-	newbody.ensure_listen_tree().AddInput(LISTEN_INPUT_DEADCHAT)
+	newbody.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_DEADCHAT)
+	newbody.ensure_listen_tree().AddListenInput(LISTEN_INPUT_DEADCHAT)
 
 	// preserve your original role;
 	// gives "???" if not an observer and not assigned a role,

--- a/code/modules/admin/toggles.dm
+++ b/code/modules/admin/toggles.dm
@@ -140,11 +140,11 @@ var/global/IP_alerts = 1
 
 	src.only_local_looc = !src.only_local_looc
 	if (src.only_local_looc)
-		src.listen_tree.AddInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
-		src.listen_tree.RemoveInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
+		src.listen_tree.AddListenInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
+		src.listen_tree.RemoveListenInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
 	else
-		src.listen_tree.AddInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
-		src.listen_tree.RemoveInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
+		src.listen_tree.AddListenInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
+		src.listen_tree.RemoveListenInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
 
 	boutput(usr, SPAN_NOTICE("Toggled seeing all LOOC messages [src.only_local_looc ?"off":"on"]!"))
 
@@ -165,16 +165,16 @@ var/global/IP_alerts = 1
 	if (global_hearing_enabled && !(src.mob_flags & MOB_HEARS_ALL))
 		src.mob_flags |= MOB_HEARS_ALL
 
-		src.listen_tree.RemoveInput(LISTEN_INPUT_EARS)
-		src.listen_tree.AddInput(LISTEN_INPUT_GLOBAL_HEARING)
-		src.listen_tree.AddInput(LISTEN_INPUT_GLOBAL_HEARING_LOCAL_COUNTERPART)
+		src.listen_tree.RemoveListenInput(LISTEN_INPUT_EARS)
+		src.listen_tree.AddListenInput(LISTEN_INPUT_GLOBAL_HEARING)
+		src.listen_tree.AddListenInput(LISTEN_INPUT_GLOBAL_HEARING_LOCAL_COUNTERPART)
 
 	else if (src.mob_flags & MOB_HEARS_ALL)
 		src.mob_flags &= ~MOB_HEARS_ALL
 
-		src.listen_tree.RemoveInput(LISTEN_INPUT_GLOBAL_HEARING)
-		src.listen_tree.RemoveInput(LISTEN_INPUT_GLOBAL_HEARING_LOCAL_COUNTERPART)
-		src.listen_tree.AddInput(LISTEN_INPUT_EARS)
+		src.listen_tree.RemoveListenInput(LISTEN_INPUT_GLOBAL_HEARING)
+		src.listen_tree.RemoveListenInput(LISTEN_INPUT_GLOBAL_HEARING_LOCAL_COUNTERPART)
+		src.listen_tree.AddListenInput(LISTEN_INPUT_EARS)
 
 /client/proc/toggle_attack_messages()
 	SET_ADMIN_CAT(ADMIN_CAT_SELF)
@@ -300,14 +300,14 @@ client/proc/toggle_ghost_respawns()
 		player_mode_mhelp = 0
 
 		if (src.preferences.listen_ooc)
-			src.listen_tree.AddInput(LISTEN_INPUT_OOC_ADMIN)
-			src.listen_tree.RemoveInput(LISTEN_INPUT_OOC)
+			src.listen_tree.AddListenInput(LISTEN_INPUT_OOC_ADMIN)
+			src.listen_tree.RemoveListenInput(LISTEN_INPUT_OOC)
 		if (src.preferences.listen_looc)
 			if (src.only_local_looc)
-				src.listen_tree.AddInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
+				src.listen_tree.AddListenInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
 			else
-				src.listen_tree.AddInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
-			src.listen_tree.RemoveInput(LISTEN_INPUT_LOOC)
+				src.listen_tree.AddListenInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
+			src.listen_tree.RemoveListenInput(LISTEN_INPUT_LOOC)
 
 		src.holder.admin_say_tree.update_target_speech_tree(src.say_tree)
 		src.holder.admin_listen_tree.update_target_listen_tree(src.listen_tree)
@@ -369,14 +369,14 @@ client/proc/toggle_ghost_respawns()
 				return
 
 		if (src.preferences.listen_ooc)
-			src.listen_tree.AddInput(LISTEN_INPUT_OOC)
-			src.listen_tree.RemoveInput(LISTEN_INPUT_OOC_ADMIN)
+			src.listen_tree.AddListenInput(LISTEN_INPUT_OOC)
+			src.listen_tree.RemoveListenInput(LISTEN_INPUT_OOC_ADMIN)
 		if (src.preferences.listen_looc)
-			src.listen_tree.AddInput(LISTEN_INPUT_LOOC)
+			src.listen_tree.AddListenInput(LISTEN_INPUT_LOOC)
 			if (src.only_local_looc)
-				src.listen_tree.RemoveInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
+				src.listen_tree.RemoveListenInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
 			else
-				src.listen_tree.RemoveInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
+				src.listen_tree.RemoveListenInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
 
 		src.holder.admin_say_tree.update_target_speech_tree()
 		src.holder.admin_listen_tree.update_target_listen_tree()
@@ -911,11 +911,11 @@ client/proc/toggle_ghost_respawns()
 
 	if (!src.deadchatoff)
 		src.deadchatoff = TRUE
-		src.listen_tree.RemoveInput(LISTEN_INPUT_DEADCHAT)
+		src.listen_tree.RemoveListenInput(LISTEN_INPUT_DEADCHAT)
 		boutput(usr, SPAN_NOTICE("No longer viewing deadchat."))
 	else
 		src.deadchatoff = FALSE
-		src.listen_tree.AddInput(LISTEN_INPUT_DEADCHAT)
+		src.listen_tree.AddListenInput(LISTEN_INPUT_DEADCHAT)
 		boutput(usr, SPAN_NOTICE("Now viewing deadchat."))
 
 /datum/admins/proc/toggleaprilfools()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -45,11 +45,8 @@
 		src.ability_holder.addAbility(/datum/targetable/changeling/boot)
 		src.ability_holder.addAbility(/datum/targetable/changeling/give_control)
 
-		var/datum/speech_module/output/bundled/hivemind/output = src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER)
-		output.subchannel = "\ref[src.ability_holder]"
-
-		var/datum/listen_module/input/bundled/hivemind/input = src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_HIVECHAT)
-		input.ChangeSubchannel("\ref[src.ability_holder]")
+		src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.ability_holder]")
 
 		if(istype(src.owner.current, /mob/living))
 			var/mob/living/L = src.owner.current
@@ -86,8 +83,8 @@
 		src.ability_holder.removeAbility(/datum/targetable/changeling/give_control)
 		src.owner.current.remove_ability_holder(/datum/abilityHolder/changeling)
 
-		src.owner.current.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER)
-		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_HIVECHAT)
+		src.owner.current.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.ability_holder]")
 
 		if(istype(src.owner.current, /mob/living))
 			var/mob/living/L = src.owner.current

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -45,8 +45,8 @@
 		src.ability_holder.addAbility(/datum/targetable/changeling/boot)
 		src.ability_holder.addAbility(/datum/targetable/changeling/give_control)
 
-		src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER, subchannel = "\ref[src.ability_holder]")
-		src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_listen_tree().AddListenInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.ability_holder]")
 
 		if(istype(src.owner.current, /mob/living))
 			var/mob/living/L = src.owner.current
@@ -83,8 +83,8 @@
 		src.ability_holder.removeAbility(/datum/targetable/changeling/give_control)
 		src.owner.current.remove_ability_holder(/datum/abilityHolder/changeling)
 
-		src.owner.current.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER, subchannel = "\ref[src.ability_holder]")
-		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.ability_holder]")
 
 		if(istype(src.owner.current, /mob/living))
 			var/mob/living/L = src.owner.current

--- a/code/modules/antagonists/changeling/changeling_critter.dm
+++ b/code/modules/antagonists/changeling/changeling_critter.dm
@@ -28,15 +28,15 @@ ABSTRACT_TYPE(/datum/antagonist/subordinate/changeling_critter)
 		src.owner.transfer_to(critter)
 		qdel(old_mob)
 
-		src.owner.current.ensure_say_tree().AddOutput(src.speech_output, subchannel = "\ref[src.master_ability_holder]")
-		src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_say_tree().AddSpeechOutput(src.speech_output, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_listen_tree().AddListenInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.master_ability_holder]")
 		src.owner.current.default_speech_output_channel = SAY_CHANNEL_HIVEMIND
 
 	remove_equipment()
 		src.master_ability_holder.hivemind -= src.owner.current
 
-		src.owner.current.ensure_say_tree().RemoveOutput(src.speech_output, subchannel = "\ref[src.master_ability_holder]")
-		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_say_tree().RemoveSpeechOutput(src.speech_output, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.master_ability_holder]")
 		src.owner.current.default_speech_output_channel = null
 
 	add_to_image_groups()

--- a/code/modules/antagonists/changeling/changeling_critter.dm
+++ b/code/modules/antagonists/changeling/changeling_critter.dm
@@ -28,19 +28,15 @@ ABSTRACT_TYPE(/datum/antagonist/subordinate/changeling_critter)
 		src.owner.transfer_to(critter)
 		qdel(old_mob)
 
-		var/datum/speech_module/output/bundled/hivemind/output = src.owner.current.ensure_say_tree().AddOutput(src.speech_output)
-		output.subchannel = "\ref[src.master_ability_holder]"
-
-		var/datum/listen_module/input/bundled/hivemind/input = src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_HIVECHAT)
-		input.ChangeSubchannel("\ref[src.master_ability_holder]")
-
+		src.owner.current.ensure_say_tree().AddOutput(src.speech_output, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.master_ability_holder]")
 		src.owner.current.default_speech_output_channel = SAY_CHANNEL_HIVEMIND
 
 	remove_equipment()
 		src.master_ability_holder.hivemind -= src.owner.current
 
-		src.owner.current.ensure_say_tree().RemoveOutput(src.speech_output)
-		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_HIVECHAT)
+		src.owner.current.ensure_say_tree().RemoveOutput(src.speech_output, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[src.master_ability_holder]")
 		src.owner.current.default_speech_output_channel = null
 
 	add_to_image_groups()

--- a/code/modules/antagonists/changeling/hivemind_member.dm
+++ b/code/modules/antagonists/changeling/hivemind_member.dm
@@ -29,8 +29,8 @@
 
 		hivemind_observer.set_owner(master_ability_holder)
 
-		src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER, subchannel = "\ref[master_ability_holder]")
-		src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[master_ability_holder]")
+		src.owner.current.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER, subchannel = "\ref[master_ability_holder]")
+		src.owner.current.ensure_listen_tree().AddListenInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[master_ability_holder]")
 		src.owner.current.default_speech_output_channel = SAY_CHANNEL_HIVEMIND
 
 	remove_equipment()

--- a/code/modules/antagonists/changeling/hivemind_member.dm
+++ b/code/modules/antagonists/changeling/hivemind_member.dm
@@ -29,12 +29,8 @@
 
 		hivemind_observer.set_owner(master_ability_holder)
 
-		var/datum/speech_module/output/bundled/hivemind/output = src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER)
-		output.subchannel = "\ref[master_ability_holder]"
-
-		var/datum/listen_module/input/bundled/hivemind/input = src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_HIVECHAT)
-		input.ChangeSubchannel("\ref[master_ability_holder]")
-
+		src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_HIVECHAT_MEMBER, subchannel = "\ref[master_ability_holder]")
+		src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_HIVECHAT, subchannel = "\ref[master_ability_holder]")
 		src.owner.current.default_speech_output_channel = SAY_CHANNEL_HIVEMIND
 
 	remove_equipment()

--- a/code/modules/antagonists/vampire/thrall.dm
+++ b/code/modules/antagonists/vampire/thrall.dm
@@ -50,8 +50,8 @@
 		src.ability_holder.addAbility(/datum/targetable/vampiric_thrall/speak)
 		src.ability_holder.addAbility(/datum/targetable/vampire/vampire_bite/thrall)
 
-		src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_THRALLCHAT_THRALL, subchannel = "\ref[src.master_ability_holder]")
-		src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_THRALLCHAT_THRALL, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_listen_tree().AddListenInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.master_ability_holder]")
 
 	remove_equipment()
 		var/mob/living/carbon/human/H = src.owner.current
@@ -66,8 +66,8 @@
 		src.ability_holder.removeAbility(/datum/targetable/vampire/vampire_bite/thrall)
 		H.remove_ability_holder(/datum/abilityHolder/vampiric_thrall)
 
-		src.owner.current.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_THRALLCHAT_THRALL, subchannel = "\ref[src.master_ability_holder]")
-		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_THRALLCHAT_THRALL, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.master_ability_holder]")
 
 	add_to_image_groups()
 		. = ..()

--- a/code/modules/antagonists/vampire/thrall.dm
+++ b/code/modules/antagonists/vampire/thrall.dm
@@ -50,11 +50,8 @@
 		src.ability_holder.addAbility(/datum/targetable/vampiric_thrall/speak)
 		src.ability_holder.addAbility(/datum/targetable/vampire/vampire_bite/thrall)
 
-		var/datum/speech_module/output/bundled/thrallchat/output = src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_THRALLCHAT_THRALL)
-		output.subchannel = "\ref[src.master_ability_holder]"
-
-		var/datum/listen_module/input/bundled/thrall/input = src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_THRALLCHAT)
-		input.ChangeSubchannel("\ref[src.master_ability_holder]")
+		src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_THRALLCHAT_THRALL, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.master_ability_holder]")
 
 	remove_equipment()
 		var/mob/living/carbon/human/H = src.owner.current
@@ -69,8 +66,8 @@
 		src.ability_holder.removeAbility(/datum/targetable/vampire/vampire_bite/thrall)
 		H.remove_ability_holder(/datum/abilityHolder/vampiric_thrall)
 
-		src.owner.current.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_THRALLCHAT)
-		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_THRALLCHAT)
+		src.owner.current.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_THRALLCHAT_THRALL, subchannel = "\ref[src.master_ability_holder]")
+		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.master_ability_holder]")
 
 	add_to_image_groups()
 		. = ..()

--- a/code/modules/antagonists/vampire/vampire.dm
+++ b/code/modules/antagonists/vampire/vampire.dm
@@ -24,8 +24,8 @@
 		src.ability_holder.addAbility(/datum/targetable/vampire/glare)
 		src.ability_holder.addAbility(/datum/targetable/vampire/hypnotize)
 
-		src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.ability_holder]")
-		src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_listen_tree().AddListenInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.ability_holder]")
 
 		src.owner.current.assign_gimmick_skull()
 
@@ -39,8 +39,8 @@
 		src.ability_holder.remove_unlocks()
 		src.owner.current.remove_ability_holder(/datum/abilityHolder/vampire)
 
-		src.owner.current.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.ability_holder]")
-		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.ability_holder]")
 
 		SPAWN(2.5 SECONDS)
 			src.owner.current.assign_gimmick_skull()

--- a/code/modules/antagonists/vampire/vampire.dm
+++ b/code/modules/antagonists/vampire/vampire.dm
@@ -24,11 +24,8 @@
 		src.ability_holder.addAbility(/datum/targetable/vampire/glare)
 		src.ability_holder.addAbility(/datum/targetable/vampire/hypnotize)
 
-		var/datum/speech_module/output/bundled/thrallchat/output = src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE)
-		output.subchannel = "\ref[src.ability_holder]"
-
-		var/datum/listen_module/input/bundled/thrall/input = src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_THRALLCHAT)
-		input.ChangeSubchannel("\ref[src.ability_holder]")
+		src.owner.current.ensure_say_tree().AddOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_listen_tree().AddInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.ability_holder]")
 
 		src.owner.current.assign_gimmick_skull()
 
@@ -42,8 +39,8 @@
 		src.ability_holder.remove_unlocks()
 		src.owner.current.remove_ability_holder(/datum/abilityHolder/vampire)
 
-		src.owner.current.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_THRALLCHAT)
-		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_THRALLCHAT)
+		src.owner.current.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.ability_holder]")
+		src.owner.current.ensure_listen_tree().RemoveInput(LISTEN_INPUT_THRALLCHAT, subchannel = "\ref[src.ability_holder]")
 
 		SPAWN(2.5 SECONDS)
 			src.owner.current.assign_gimmick_skull()

--- a/code/modules/antagonists/wraith/abilties/_wraith_ability_holder.dm
+++ b/code/modules/antagonists/wraith/abilties/_wraith_ability_holder.dm
@@ -156,11 +156,11 @@
 
 		W.hearghosts = !W.hearghosts
 		if (W.hearghosts)
-			W.ensure_listen_tree().AddInput(LISTEN_INPUT_DEADCHAT)
+			W.ensure_listen_tree().AddListenInput(LISTEN_INPUT_DEADCHAT)
 			src.icon_state = "hide_chat"
 			boutput(W, SPAN_NOTICE("Now listening to the dead again."))
 		else
-			W.ensure_listen_tree().RemoveInput(LISTEN_INPUT_DEADCHAT)
+			W.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_DEADCHAT)
 			src.icon_state = "show_chat"
 			boutput(W, SPAN_NOTICE("No longer listening to the dead."))
 

--- a/code/modules/events/vamp_teg.dm
+++ b/code/modules/events/vamp_teg.dm
@@ -236,7 +236,7 @@ datum/teg_transformation/vampire
 		vampify(src.teg.circ2)
 		vampify(src.teg)
 
-		teg.ensure_say_tree().AddOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.abilityHolder]")
+		teg.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.abilityHolder]")
 		teg.default_speech_output_channel = SAY_CHANNEL_THRALL
 
 	proc/vampify(obj/O)
@@ -273,7 +273,7 @@ datum/teg_transformation/vampire
 		for(var/mob/M in abilityHolder.thralls)
 			M.mind?.remove_antagonist(ROLE_VAMPTHRALL)
 
-		teg.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.abilityHolder]")
+		teg.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.abilityHolder]")
 		teg.default_speech_output_channel = SAY_CHANNEL_OUTLOUD
 
 		. = ..()

--- a/code/modules/events/vamp_teg.dm
+++ b/code/modules/events/vamp_teg.dm
@@ -236,8 +236,7 @@ datum/teg_transformation/vampire
 		vampify(src.teg.circ2)
 		vampify(src.teg)
 
-		var/datum/speech_module/output/bundled/thrallchat/output = teg.ensure_say_tree().AddOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE)
-		output.subchannel = "\ref[src.abilityHolder]"
+		teg.ensure_say_tree().AddOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.abilityHolder]")
 		teg.default_speech_output_channel = SAY_CHANNEL_THRALL
 
 	proc/vampify(obj/O)
@@ -274,7 +273,7 @@ datum/teg_transformation/vampire
 		for(var/mob/M in abilityHolder.thralls)
 			M.mind?.remove_antagonist(ROLE_VAMPTHRALL)
 
-		teg.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_THRALLCHAT)
+		teg.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_THRALLCHAT_VAMPIRE, subchannel = "\ref[src.abilityHolder]")
 		teg.default_speech_output_channel = SAY_CHANNEL_OUTLOUD
 
 		. = ..()

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -535,7 +535,7 @@
 	onPowerChange(oldval, newval)
 		src.owner.ensure_listen_tree()
 		if (src.current_module)
-			src.owner.listen_tree.RemoveInput(src.current_module)
+			src.owner.listen_tree.RemoveListenInput(src.current_module)
 
 		switch (newval)
 			if (1)
@@ -545,13 +545,13 @@
 			else
 				src.current_module = LISTEN_INPUT_RADIO_GLOBAL
 
-		src.owner.listen_tree.AddInput(src.current_module)
+		src.owner.listen_tree.AddListenInput(src.current_module)
 
 	OnRemove()
 		if (!src.current_module)
 			return
 
-		src.owner.ensure_listen_tree().RemoveInput(src.current_module)
+		src.owner.ensure_listen_tree().RemoveListenInput(src.current_module)
 
 
 /datum/bioEffect/hulk

--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -42,10 +42,10 @@
 
 	OnAdd()
 		. = ..()
-		owner.ensure_say_tree().AddModifier(SPEECH_MODIFIER_MUTE)
+		owner.ensure_say_tree().AddSpeechModifier(SPEECH_MODIFIER_MUTE)
 
 	OnRemove()
-		owner.ensure_say_tree().RemoveModifier(SPEECH_MODIFIER_MUTE)
+		owner.ensure_say_tree().RemoveSpeechModifier(SPEECH_MODIFIER_MUTE)
 		. = ..()
 
 /datum/bioEffect/deaf

--- a/code/modules/medical/genetics/bioEffects/speech.dm
+++ b/code/modules/medical/genetics/bioEffects/speech.dm
@@ -17,10 +17,10 @@
 	var/mixingdesk_allowed = TRUE
 
 	OnAdd()
-		src.owner.ensure_say_tree().AddModifier(src.id)
+		src.owner.ensure_say_tree().AddSpeechModifier(src.id)
 
 	OnRemove()
-		src.owner.ensure_say_tree().RemoveModifier(src.id)
+		src.owner.ensure_say_tree().RemoveSpeechModifier(src.id)
 
 
 /datum/bioEffect/speech/smile

--- a/code/modules/mentor/mentorhelp.dm
+++ b/code/modules/mentor/mentorhelp.dm
@@ -34,12 +34,12 @@
 		// provide temp access to speak on this channel if, somehow, we didn't have it before
 		var/channel_access = length(client.mob.ensure_say_tree().GetOutputsByChannel(SAY_CHANNEL_MENTOR_MOUSE)) > 0
 		if (!channel_access)
-			client.mob.ensure_say_tree().AddOutput(SPEECH_OUTPUT_MENTOR_MOUSE)
-			client.mob.ensure_listen_tree().AddInput(LISTEN_INPUT_MENTOR_MOUSE)
+			client.mob.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_MENTOR_MOUSE)
+			client.mob.ensure_listen_tree().AddListenInput(LISTEN_INPUT_MENTOR_MOUSE)
 		client.mob.say(msg, message_params = list("output_module_channel" = SAY_CHANNEL_MENTOR_MOUSE), atom_listeners_override = list(client.mob, mmouse))
 		if (!channel_access)
-			client.mob.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_MENTOR_MOUSE)
-			client.mob.ensure_listen_tree().RemoveInput(LISTEN_INPUT_MENTOR_MOUSE)
+			client.mob.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_MENTOR_MOUSE)
+			client.mob.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_MENTOR_MOUSE)
 		return
 
 	if (client.player.cloudSaves.getData("mentorhelp_banner"))

--- a/code/modules/mentor/mentorhelp.dm
+++ b/code/modules/mentor/mentorhelp.dm
@@ -32,7 +32,7 @@
 	if(mmouse) // mouse in your pocket takes precedence over mhelps
 		var/msg = input("Please enter your whispers to the mouse:") as null|text
 		// provide temp access to speak on this channel if, somehow, we didn't have it before
-		var/channel_access = length(client.mob.ensure_say_tree().GetOutputByChannel(SAY_CHANNEL_MENTOR_MOUSE)) > 0
+		var/channel_access = length(client.mob.ensure_say_tree().GetOutputsByChannel(SAY_CHANNEL_MENTOR_MOUSE)) > 0
 		if (!channel_access)
 			client.mob.ensure_say_tree().AddOutput(SPEECH_OUTPUT_MENTOR_MOUSE)
 			client.mob.ensure_listen_tree().AddInput(LISTEN_INPUT_MENTOR_MOUSE)

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -112,7 +112,7 @@
 			cam = null
 		..()
 
-	say(message, flags, message_params, atom_listeners_override)
+	say(message, flags, list/message_params, list/atom/atom_listeners_override)
 		if (!src.on || src.muted)
 			return
 

--- a/code/modules/speech/core.dm
+++ b/code/modules/speech/core.dm
@@ -4,7 +4,7 @@
 /atom/var/list/start_listen_modifiers
 /// The listen inputs that this atom *starts* with. It will not be updated nor used again after initialisation.
 /atom/var/list/start_listen_inputs
-/// The listen languages that this atom *starts* with. It will not be updated nor used again after initialisation. Note this is the languages that the atom understands when heard.
+/// The listen languages that this atom *starts* with. It will not be updated nor used again after initialisation. Note that this is the languages that the atom understands when heard.
 /atom/var/list/start_listen_languages
 
 /atom/New()
@@ -145,14 +145,9 @@ Contributing:
 	Thorough documentation,
 	The use of `src` and `global` when accessing applicable variables.
 
-Limitations To Later Code Out:
-- Currently tree can only support one instance of each module ID - this is not ideal for delimited listen and speech modules.
-
 Cleanup:
 - Move say procs into this directory.
 - Tidy speech variables on types. Especially mobs. (search for speech_verb_)
-- `VAR_PRIVATE` where necessary.
-- `RETURN_TYPE` where necessary.
 
 Old Code To Remove:
 - `proc/speak`. `all_hearers` implementations may be good to look at too.

--- a/code/modules/speech/core.dm
+++ b/code/modules/speech/core.dm
@@ -209,15 +209,15 @@ Follow-Up PRs:
 
 	if (src.preferences.listen_ooc)
 		if (src.holder && !src.player_mode)
-			src.listen_tree.AddInput(LISTEN_INPUT_OOC_ADMIN)
+			src.listen_tree.AddListenInput(LISTEN_INPUT_OOC_ADMIN)
 		else
-			src.listen_tree.AddInput(LISTEN_INPUT_OOC)
+			src.listen_tree.AddListenInput(LISTEN_INPUT_OOC)
 
 	else
 		if (src.holder && !src.player_mode)
-			src.listen_tree.RemoveInput(LISTEN_INPUT_OOC_ADMIN)
+			src.listen_tree.RemoveListenInput(LISTEN_INPUT_OOC_ADMIN)
 		else
-			src.listen_tree.RemoveInput(LISTEN_INPUT_OOC)
+			src.listen_tree.RemoveListenInput(LISTEN_INPUT_OOC)
 
 /client/proc/toggle_looc(looc_enabled)
 	if (src.preferences.listen_looc == looc_enabled)
@@ -228,20 +228,20 @@ Follow-Up PRs:
 	if (src.preferences.listen_looc)
 		if (src.holder && !src.player_mode)
 			if (src.only_local_looc)
-				src.listen_tree.AddInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
+				src.listen_tree.AddListenInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
 			else
-				src.listen_tree.AddInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
+				src.listen_tree.AddListenInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
 		else
-			src.listen_tree.AddInput(LISTEN_INPUT_LOOC)
+			src.listen_tree.AddListenInput(LISTEN_INPUT_LOOC)
 
 	else
 		if (src.holder && !src.player_mode)
 			if (src.only_local_looc)
-				src.listen_tree.RemoveInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
+				src.listen_tree.RemoveListenInput(LISTEN_INPUT_LOOC_ADMIN_LOCAL)
 			else
-				src.listen_tree.RemoveInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
+				src.listen_tree.RemoveListenInput(LISTEN_INPUT_LOOC_ADMIN_GLOBAL)
 		else
-			src.listen_tree.RemoveInput(LISTEN_INPUT_LOOC)
+			src.listen_tree.RemoveListenInput(LISTEN_INPUT_LOOC)
 
 /mob/Login()
 	. = ..()

--- a/code/modules/speech/languages/_language_parent.dm
+++ b/code/modules/speech/languages/_language_parent.dm
@@ -9,10 +9,12 @@
 
 /// Processes a say message datum that has been understood by the listener, typically not altering it.
 /datum/language/proc/heard_understood(datum/say_message/message, datum/listen_module_tree/listen_tree)
+	RETURN_TYPE(/datum/say_message)
 	return message
 
 /// Processes a say message datum that has not been understood by the listener, typically either deleting it, or turning its content to gibberish.
 /datum/language/proc/heard_not_understood(datum/say_message/message, datum/listen_module_tree/listen_tree)
-	. = message
+	RETURN_TYPE(/datum/say_message)
 
 	message.speaker_to_display = message.voice_ident
+	return message

--- a/code/modules/speech/message_modifiers/_message_modifier_parent.dm
+++ b/code/modules/speech/message_modifiers/_message_modifier_parent.dm
@@ -12,6 +12,7 @@ ABSTRACT_TYPE(/datum/message_modifier)
 
 /// Handle all processing that pertains to the say pipeline. Return `null` to prevent the message being processed further, or a `/datum/say_message` instance to continue.
 /datum/message_modifier/proc/process(datum/say_message/message)
+	RETURN_TYPE(/datum/say_message)
 	return message
 
 

--- a/code/modules/speech/modules/inputs/_input_module_parent.dm
+++ b/code/modules/speech/modules/inputs/_input_module_parent.dm
@@ -27,18 +27,6 @@ ABSTRACT_TYPE(/datum/listen_module/input)
 	message.received_module = src
 	src.parent_tree.process(message)
 
-/// Changes the channel this listen module should be registered to and re-registers it.
-/datum/listen_module/input/proc/ChangeChannel(new_channel)
-	src.say_channel.UnregisterInput(src)
-	src.say_channel = null
-	src.parent_tree.input_modules_by_channel[src.channel] -= src
-
-	src.channel = new_channel
-	src.say_channel = global.SpeechManager.GetSayChannelInstance(src.channel)
-	src.say_channel.RegisterInput(src)
-	src.parent_tree.input_modules_by_channel[src.channel] ||= list()
-	src.parent_tree.input_modules_by_channel[src.channel] += src
-
 
 ABSTRACT_TYPE(/datum/listen_module/input/bundled)
 /**
@@ -48,8 +36,7 @@ ABSTRACT_TYPE(/datum/listen_module/input/bundled)
 /datum/listen_module/input/bundled
 	var/subchannel = "none"
 
-/// Changes the subchannel this listen module should be registered to and re-registers it.
-/datum/listen_module/input/bundled/proc/ChangeSubchannel(new_subchannel)
-	src.say_channel.UnregisterInput(src)
-	src.subchannel = new_subchannel
-	src.say_channel.RegisterInput(src)
+/datum/listen_module/input/bundled/New(datum/listen_module_tree/parent, subchannel)
+	src.subchannel = subchannel
+
+	. = ..()

--- a/code/modules/speech/modules/module_parents.dm
+++ b/code/modules/speech/modules/module_parents.dm
@@ -8,9 +8,19 @@ ABSTRACT_TYPE(/datum/speech_module)
 	var/id = "abstract_base"
 	/// How far up the tree this module should go. High values get processed before low values.
 	var/priority = 0
+	/// The speech tree that this module belongs to.
+	var/datum/speech_module_tree/parent_tree
+
+/datum/speech_module/New(datum/speech_module_tree/parent)
+	. = ..()
+	if (!istype(parent))
+		CRASH("Tried to instantiate a speech module without a parent speech tree. You can't do that!")
+
+	src.parent_tree = parent
 
 /// Process the message, applying module specific effects. Return `null` to prevent the message being processed further, or a `/datum/say_message` instance to continue.
 /datum/speech_module/proc/process(datum/say_message/message)
+	RETURN_TYPE(/datum/say_message)
 	return message
 
 
@@ -41,4 +51,5 @@ ABSTRACT_TYPE(/datum/listen_module)
 
 /// Process the message, applying module specific effects. Return `null` to prevent the message being processed further, or a `/datum/say_message` instance to continue.
 /datum/listen_module/proc/process(datum/say_message/message)
+	RETURN_TYPE(/datum/say_message)
 	return message

--- a/code/modules/speech/modules/outputs/_output_module_parent.dm
+++ b/code/modules/speech/modules/outputs/_output_module_parent.dm
@@ -10,15 +10,10 @@ ABSTRACT_TYPE(/datum/speech_module/output)
 	var/channel = "none"
 	/// The say channel datum that this module should pass say messages to.
 	var/datum/say_channel/say_channel
-	/// The speech tree that this module belongs to.
-	var/datum/speech_module_tree/parent_tree
 
 /datum/speech_module/output/New(datum/speech_module_tree/parent)
 	. = ..()
-	if (!istype(parent))
-		CRASH("Tried to instantiate a listen input without a parent listen tree. You can't do that!")
 
-	src.parent_tree = parent
 	src.say_channel = global.SpeechManager.GetSayChannelInstance(src.channel)
 	src.say_channel.RegisterOutput(src)
 
@@ -41,6 +36,11 @@ ABSTRACT_TYPE(/datum/speech_module/output/bundled)
  */
 /datum/speech_module/output/bundled
 	var/subchannel = "none"
+
+/datum/speech_module/output/bundled/New(datum/speech_module_tree/parent, subchannel)
+	src.subchannel = subchannel
+
+	. = ..()
 
 /datum/speech_module/output/bundled/process(datum/say_message/message)
 	PASS_MESSAGE_TO_SAY_CHANNEL(src.say_channel, message, src.subchannel)

--- a/code/modules/speech/modules/outputs/flock.dm
+++ b/code/modules/speech/modules/outputs/flock.dm
@@ -4,9 +4,10 @@
 	var/datum/flock/flock
 	var/datum/say_channel/distorted_flock/distorted_flock_channel
 
-/datum/speech_module/output/bundled/flock_say/New()
+/datum/speech_module/output/bundled/flock_say/New(datum/speech_module_tree/parent, subchannel, datum/flock/flock)
 	. = ..()
 
+	src.flock = flock
 	src.distorted_flock_channel = global.SpeechManager.GetSayChannelInstance(SAY_CHANNEL_DISTORTED_FLOCK)
 
 /datum/speech_module/output/bundled/flock_say/process(datum/say_message/message)

--- a/code/modules/speech/prefixes/_say_prefix_parent.dm
+++ b/code/modules/speech/prefixes/_say_prefix_parent.dm
@@ -17,4 +17,5 @@ ABSTRACT_TYPE(/datum/say_prefix)
 
 /// Process the message, applying prefix specific effects. This typically involves copying the message and sending it to an equipped module.
 /datum/say_prefix/proc/process(datum/say_message/message, datum/speech_module_tree/say_tree)
+	RETURN_TYPE(/datum/say_message)
 	return message

--- a/code/modules/speech/prefixes/deadchat.dm
+++ b/code/modules/speech/prefixes/deadchat.dm
@@ -5,7 +5,7 @@
 	return ismob(message.speaker) && inafterlife(message.speaker)
 
 /datum/say_prefix/deadchat/process(datum/say_message/message, datum/speech_module_tree/say_tree)
-	var/list/datum/speech_module/output/output_modules = say_tree.GetOutputByChannel(SAY_CHANNEL_DEAD)
+	var/list/datum/speech_module/output/output_modules = say_tree.GetOutputsByChannel(SAY_CHANNEL_DEAD)
 	if (!length(output_modules))
 		return
 

--- a/code/modules/speech/say_channels/_say_channel_parent.dm
+++ b/code/modules/speech/say_channels/_say_channel_parent.dm
@@ -61,7 +61,7 @@ ABSTRACT_TYPE(/datum/say_channel)
 		if (!A.listen_tree)
 			continue
 
-		for (var/datum/listen_module/input/input as anything in A.listen_tree.input_modules_by_channel[src.channel_id])
+		for (var/datum/listen_module/input/input as anything in A.listen_tree.GetInputsByChannel(src.channel_id))
 			listen_modules_by_type[input.type] ||= list()
 			listen_modules_by_type[input.type] += input
 

--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -382,6 +382,8 @@ var/regex/forbidden_character_regex = regex(@"[\u2028\u202a\u202b\u202c\u202d\u2
 
 /// Create a copy of this say message datum.
 /datum/say_message/proc/Copy()
+	RETURN_TYPE(/datum/say_message)
+
 	var/datum/say_message/copy = new(is_copy = TRUE)
 	for (var/V in src.vars)
 		if (!issaved(src.vars[V]))

--- a/code/modules/speech/say_sources/_abstract_say_source_parent.dm
+++ b/code/modules/speech/say_sources/_abstract_say_source_parent.dm
@@ -37,7 +37,7 @@
 	src.radio = new src.radio_type(src)
 	src.radio.toggle_microphone(FALSE)
 	src.radio.toggle_speaker(FALSE)
-	src.radio.ensure_listen_tree().AddInput(LISTEN_INPUT_EQUIPPED)
+	src.radio.ensure_listen_tree().AddListenInput(LISTEN_INPUT_EQUIPPED)
 
 	src.radio.set_frequency(src.default_frequency)
 	src.radio.chat_class = src.radio_chat_class

--- a/code/modules/speech/say_sources/flock_system.dm
+++ b/code/modules/speech/say_sources/flock_system.dm
@@ -1,11 +1,9 @@
 /atom/movable/abstract_say_source/flock_system
-	start_speech_outputs = list(SPEECH_OUTPUT_FLOCK_SYSTEM)
+	start_speech_outputs = null
 	default_speech_output_channel = SAY_CHANNEL_FLOCK
 	say_language = LANGUAGE_FEATHER
 
 /atom/movable/abstract_say_source/flock_system/New(loc, datum/flock/flock)
 	. = ..()
 
-	var/datum/speech_module/output/bundled/flock_say/system/output = src.ensure_say_tree().GetOutputByID(SPEECH_OUTPUT_FLOCK_SYSTEM)
-	output.flock = flock
-	output.subchannel = "\ref[flock]"
+	src.ensure_say_tree().AddOutput(SPEECH_OUTPUT_FLOCK_SYSTEM, subchannel = "\ref[flock]", flock = flock)

--- a/code/modules/speech/say_sources/flock_system.dm
+++ b/code/modules/speech/say_sources/flock_system.dm
@@ -6,4 +6,4 @@
 /atom/movable/abstract_say_source/flock_system/New(loc, datum/flock/flock)
 	. = ..()
 
-	src.ensure_say_tree().AddOutput(SPEECH_OUTPUT_FLOCK_SYSTEM, subchannel = "\ref[flock]", flock = flock)
+	src.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_FLOCK_SYSTEM, subchannel = "\ref[flock]", flock = flock)

--- a/code/modules/speech/say_sources/mixing_desk.dm
+++ b/code/modules/speech/say_sources/mixing_desk.dm
@@ -7,7 +7,7 @@
 	src.parent = loc
 	src.name = name
 	if (accent_id)
-		src.ensure_say_tree().AddModifier(accent_id)
+		src.ensure_say_tree().AddSpeechModifier(accent_id)
 
 /atom/movable/abstract_say_source/mixing_desk/disposing()
 	src.parent.voice_say_sources -= src

--- a/code/modules/speech/say_sources/random_accent.dm
+++ b/code/modules/speech/say_sources/random_accent.dm
@@ -8,10 +8,9 @@ var/atom/movable/abstract_say_source/random_accent/random_accent_source = new()
 /atom/movable/abstract_say_source/random_accent/proc/process_message(message)
 	RETURN_TYPE(/datum/say_message)
 
+	qdel(src.say_tree)
+	src.say_tree = null
 	src.ensure_say_tree()
-
-	for (var/modifier_id in src.say_tree.speech_modifiers_by_id)
-		src.say_tree.RemoveModifier(modifier_id)
 
 	while (prob(5))
 		src.say_tree.AddModifier(global.random_accent().id)

--- a/code/modules/speech/say_sources/random_accent.dm
+++ b/code/modules/speech/say_sources/random_accent.dm
@@ -13,6 +13,6 @@ var/atom/movable/abstract_say_source/random_accent/random_accent_source = new()
 	src.ensure_say_tree()
 
 	while (prob(5))
-		src.say_tree.AddModifier(global.random_accent().id)
+		src.say_tree.AddSpeechModifier(global.random_accent().id)
 
 	return src.say(message, flags = SAYFLAG_DO_NOT_OUTPUT)

--- a/code/modules/speech/speech_manager.dm
+++ b/code/modules/speech/speech_manager.dm
@@ -6,13 +6,13 @@ var/global/datum/speech_manager/SpeechManager = new()
  */
 /datum/speech_manager
 	/// An associative list of cached modifier speech module types, indexed by their ID.
-	VAR_PRIVATE/list/modifier_cache
+	VAR_PRIVATE/list/speech_modifier_cache
 	/// An associative list of cached output speech module types, indexed by their ID.
 	VAR_PRIVATE/list/output_cache
 	/// An associative list of cached input listen module types, indexed by their ID.
 	VAR_PRIVATE/list/input_cache
 	/// An associative list of cached modifier listen module types, indexed by their ID.
-	VAR_PRIVATE/list/listen_mod_cache
+	VAR_PRIVATE/list/listen_modifier_cache
 
 	/// An associative list of cached shared input format module datum singletons, indexed by their ID.
 	VAR_PRIVATE/list/datum/shared_input_format_module/shared_input_format_cache
@@ -37,19 +37,19 @@ var/global/datum/speech_manager/SpeechManager = new()
 	. = ..()
 
 	// Populate the module caches.
-	src.modifier_cache = list()
-	for (var/datum/speech_module/modifier/T as anything in concrete_typesof(/datum/speech_module/modifier))
-		var/module_id = initial(T.id)
-		if (src.modifier_cache[module_id])
-			CRASH("Non unique modifier found: [module_id]. These MUST be unique.")
-		src.modifier_cache[module_id] = T
-
 	src.output_cache = list()
 	for (var/datum/speech_module/output/T as anything in concrete_typesof(/datum/speech_module/output))
 		var/module_id = initial(T.id)
 		if (src.output_cache[module_id])
 			CRASH("Non unique output found: [module_id]. These MUST be unique.")
 		src.output_cache[module_id] = T
+
+	src.speech_modifier_cache = list()
+	for (var/datum/speech_module/modifier/T as anything in concrete_typesof(/datum/speech_module/modifier))
+		var/module_id = initial(T.id)
+		if (src.speech_modifier_cache[module_id])
+			CRASH("Non unique modifier found: [module_id]. These MUST be unique.")
+		src.speech_modifier_cache[module_id] = T
 
 	src.input_cache = list()
 	for (var/datum/listen_module/input/T as anything in concrete_typesof(/datum/listen_module/input))
@@ -58,12 +58,12 @@ var/global/datum/speech_manager/SpeechManager = new()
 			CRASH("Non unique input found: [module_id]. These MUST be unique.")
 		src.input_cache[module_id] = T
 
-	src.listen_mod_cache = list()
+	src.listen_modifier_cache = list()
 	for (var/datum/listen_module/modifier/T as anything in concrete_typesof(/datum/listen_module/modifier))
 		var/module_id = initial(T.id)
-		if (src.listen_mod_cache[module_id])
+		if (src.listen_modifier_cache[module_id])
 			CRASH("Non unique listen modifer found: [module_id]. These MUST be unique.")
-		src.listen_mod_cache[module_id] = T
+		src.listen_modifier_cache[module_id] = T
 
 	// Populate the shared input format module cache.
 	src.shared_input_format_cache = list()
@@ -111,41 +111,41 @@ var/global/datum/speech_manager/SpeechManager = new()
 
 	sortList(src.postprocessing_message_modifier_cache, GLOBAL_PROC_REF(cmp_message_modifier), TRUE)
 
-/// Returns a unique instance of the modifier speech module requested, or runtimes on bad ID.
-/datum/speech_manager/proc/GetSpeechModifierInstance(mod_id)
-	RETURN_TYPE(/datum/speech_module/modifier)
-	var/result = src.modifier_cache[mod_id]
-	if (result)
-		return new result()
-	else
-		CRASH("Invalid modifier lookup: [mod_id]")
-
 /// Returns a unique instance of the output speech module requested, or runtimes on bad ID.
-/datum/speech_manager/proc/GetOutputInstance(output_id, datum/listen_module_tree/parent)
+/datum/speech_manager/proc/GetOutputInstance(output_id, list/arguments)
 	RETURN_TYPE(/datum/speech_module/output)
 	var/result = src.output_cache[output_id]
 	if (result)
-		return new result(parent)
+		return new result(arglist(arguments))
 	else
 		CRASH("Invalid output lookup: [output_id]")
 
+/// Returns a unique instance of the modifier speech module requested, or runtimes on bad ID.
+/datum/speech_manager/proc/GetSpeechModifierInstance(modifier_id, list/arguments)
+	RETURN_TYPE(/datum/speech_module/modifier)
+	var/result = src.speech_modifier_cache[modifier_id]
+	if (result)
+		return new result(arglist(arguments))
+	else
+		CRASH("Invalid modifier lookup: [modifier_id]")
+
 /// Returns a unique instance of the input listen module requested, or runtimes on bad ID.
-/datum/speech_manager/proc/GetInputInstance(input_id, datum/listen_module_tree/parent)
+/datum/speech_manager/proc/GetInputInstance(input_id, list/arguments)
 	RETURN_TYPE(/datum/listen_module/input)
 	var/result = src.input_cache[input_id]
 	if (result)
-		return new result(parent)
+		return new result(arglist(arguments))
 	else
 		CRASH("Invalid input lookup: [input_id]")
 
 /// Returns a unique instance of the modifier listen module requested, or runtimes on bad ID.
-/datum/speech_manager/proc/GetListenModifierInstance(mod_id, datum/listen_module_tree/parent)
+/datum/speech_manager/proc/GetListenModifierInstance(modifier_id, list/arguments)
 	RETURN_TYPE(/datum/listen_module/modifier)
-	var/result = src.listen_mod_cache[mod_id]
+	var/result = src.listen_modifier_cache[modifier_id]
 	if (result)
-		return new result(parent)
+		return new result(arglist(arguments))
 	else
-		CRASH("Invalid listen modifier lookup: [mod_id]")
+		CRASH("Invalid listen modifier lookup: [modifier_id]")
 
 /// Returns the global instance of the shared input module datum corresponding to the ID given. Does not runtime of bad ID.
 /datum/speech_manager/proc/GetSharedInputFormatModuleInstance(module_id)

--- a/code/modules/speech/trees/auxiliary_listen_module_tree.dm
+++ b/code/modules/speech/trees/auxiliary_listen_module_tree.dm
@@ -20,40 +20,40 @@
 /datum/listen_module_tree/auxiliary/flush_message_buffer()
 	return
 
-/datum/listen_module_tree/auxiliary/AddInput(input_id)
-	src.target_listen_tree?.AddInput(input_id)
+/datum/listen_module_tree/auxiliary/_AddInput(input_id, arguments, count)
+	src.target_listen_tree?._AddInput(input_id, arguments, count)
 	. = ..()
 
-/datum/listen_module_tree/auxiliary/RemoveInput(input_id)
-	src.target_listen_tree?.RemoveInput(input_id)
+/datum/listen_module_tree/auxiliary/RemoveInput(input_id, subchannel, count)
+	src.target_listen_tree?.RemoveInput(input_id, subchannel, count)
 	. = ..()
 
-/datum/listen_module_tree/auxiliary/AddModifier(modifier_id)
-	src.target_listen_tree?.AddModifier(modifier_id)
+/datum/listen_module_tree/auxiliary/_AddModifier(modifier_id, arguments, count)
+	src.target_listen_tree?._AddModifier(modifier_id, arguments, count)
 	. = ..()
 
-/datum/listen_module_tree/auxiliary/RemoveModifier(modifier_id)
-	src.target_listen_tree?.RemoveModifier(modifier_id)
+/datum/listen_module_tree/auxiliary/RemoveModifier(modifier_id, count)
+	src.target_listen_tree?.RemoveModifier(modifier_id, count)
 	. = ..()
 
-/datum/listen_module_tree/auxiliary/AddKnownLanguage(language_id)
-	src.target_listen_tree?.AddKnownLanguage(language_id)
+/datum/listen_module_tree/auxiliary/AddKnownLanguage(language_id, count)
+	src.target_listen_tree?.AddKnownLanguage(language_id, count)
 	. = ..()
 
-/datum/listen_module_tree/auxiliary/RemoveKnownLanguage(language_id)
-	src.target_listen_tree?.RemoveKnownLanguage(language_id)
+/datum/listen_module_tree/auxiliary/RemoveKnownLanguage(language_id, count)
+	src.target_listen_tree?.RemoveKnownLanguage(language_id, count)
 	. = ..()
 
 /datum/listen_module_tree/auxiliary/proc/update_target_listen_tree(datum/listen_module_tree/listen_tree)
 	if (src.target_listen_tree)
 		for (var/input_id in src.input_module_ids_with_subcount)
-			src.target_listen_tree.RemoveInput(input_id, src.input_module_ids_with_subcount[input_id])
+			src.target_listen_tree.RemoveInput(input_id, count = src.input_module_ids_with_subcount[input_id])
 
 		for (var/modifier_id in src.listen_modifier_ids_with_subcount)
-			src.target_listen_tree.RemoveModifier(modifier_id, src.listen_modifier_ids_with_subcount[modifier_id])
+			src.target_listen_tree.RemoveModifier(modifier_id, count = src.listen_modifier_ids_with_subcount[modifier_id])
 
 		for (var/language_id in src.known_languages_by_id)
-			src.target_listen_tree.RemoveKnownLanguage(language_id, src.known_language_ids_with_subcount[language_id])
+			src.target_listen_tree.RemoveKnownLanguage(language_id, count = src.known_language_ids_with_subcount[language_id])
 
 		if (src.understands_all_languages)
 			src.target_listen_tree.RemoveKnownLanguage(LANGUAGE_ALL)
@@ -65,13 +65,13 @@
 		return
 
 	for (var/input_id in src.input_module_ids_with_subcount)
-		src.target_listen_tree.AddInput(input_id, src.input_module_ids_with_subcount[input_id])
+		src.target_listen_tree._AddInput(input_id, count = src.input_module_ids_with_subcount[input_id])
 
 	for (var/modifier_id in src.listen_modifier_ids_with_subcount)
-		src.target_listen_tree.AddModifier(modifier_id, src.listen_modifier_ids_with_subcount[modifier_id])
+		src.target_listen_tree._AddModifier(modifier_id, count = src.listen_modifier_ids_with_subcount[modifier_id])
 
 	for (var/language_id in src.known_languages_by_id)
-		src.target_listen_tree.AddKnownLanguage(language_id, src.known_language_ids_with_subcount[language_id])
+		src.target_listen_tree.AddKnownLanguage(language_id, count = src.known_language_ids_with_subcount[language_id])
 
 	if (src.understands_all_languages)
 		src.target_listen_tree.AddKnownLanguage(LANGUAGE_ALL)

--- a/code/modules/speech/trees/auxiliary_listen_module_tree.dm
+++ b/code/modules/speech/trees/auxiliary_listen_module_tree.dm
@@ -20,20 +20,20 @@
 /datum/listen_module_tree/auxiliary/flush_message_buffer()
 	return
 
-/datum/listen_module_tree/auxiliary/_AddInput(input_id, arguments, count)
-	src.target_listen_tree?._AddInput(input_id, arguments, count)
+/datum/listen_module_tree/auxiliary/_AddListenInput(input_id, arguments, count)
+	src.target_listen_tree?._AddListenInput(input_id, arguments, count)
 	. = ..()
 
-/datum/listen_module_tree/auxiliary/RemoveInput(input_id, subchannel, count)
-	src.target_listen_tree?.RemoveInput(input_id, subchannel, count)
+/datum/listen_module_tree/auxiliary/RemoveListenInput(input_id, subchannel, count)
+	src.target_listen_tree?.RemoveListenInput(input_id, subchannel, count)
 	. = ..()
 
-/datum/listen_module_tree/auxiliary/_AddModifier(modifier_id, arguments, count)
-	src.target_listen_tree?._AddModifier(modifier_id, arguments, count)
+/datum/listen_module_tree/auxiliary/_AddListenModifier(modifier_id, arguments, count)
+	src.target_listen_tree?._AddListenModifier(modifier_id, arguments, count)
 	. = ..()
 
-/datum/listen_module_tree/auxiliary/RemoveModifier(modifier_id, count)
-	src.target_listen_tree?.RemoveModifier(modifier_id, count)
+/datum/listen_module_tree/auxiliary/RemoveListenModifier(modifier_id, count)
+	src.target_listen_tree?.RemoveListenModifier(modifier_id, count)
 	. = ..()
 
 /datum/listen_module_tree/auxiliary/AddKnownLanguage(language_id, count)
@@ -47,10 +47,10 @@
 /datum/listen_module_tree/auxiliary/proc/update_target_listen_tree(datum/listen_module_tree/listen_tree)
 	if (src.target_listen_tree)
 		for (var/input_id in src.input_module_ids_with_subcount)
-			src.target_listen_tree.RemoveInput(input_id, count = src.input_module_ids_with_subcount[input_id])
+			src.target_listen_tree.RemoveListenInput(input_id, count = src.input_module_ids_with_subcount[input_id])
 
 		for (var/modifier_id in src.listen_modifier_ids_with_subcount)
-			src.target_listen_tree.RemoveModifier(modifier_id, count = src.listen_modifier_ids_with_subcount[modifier_id])
+			src.target_listen_tree.RemoveListenModifier(modifier_id, count = src.listen_modifier_ids_with_subcount[modifier_id])
 
 		for (var/language_id in src.known_languages_by_id)
 			src.target_listen_tree.RemoveKnownLanguage(language_id, count = src.known_language_ids_with_subcount[language_id])
@@ -65,10 +65,10 @@
 		return
 
 	for (var/input_id in src.input_module_ids_with_subcount)
-		src.target_listen_tree._AddInput(input_id, count = src.input_module_ids_with_subcount[input_id])
+		src.target_listen_tree._AddListenInput(input_id, count = src.input_module_ids_with_subcount[input_id])
 
 	for (var/modifier_id in src.listen_modifier_ids_with_subcount)
-		src.target_listen_tree._AddModifier(modifier_id, count = src.listen_modifier_ids_with_subcount[modifier_id])
+		src.target_listen_tree._AddListenModifier(modifier_id, count = src.listen_modifier_ids_with_subcount[modifier_id])
 
 	for (var/language_id in src.known_languages_by_id)
 		src.target_listen_tree.AddKnownLanguage(language_id, count = src.known_language_ids_with_subcount[language_id])

--- a/code/modules/speech/trees/auxiliary_speech_module_tree.dm
+++ b/code/modules/speech/trees/auxiliary_speech_module_tree.dm
@@ -17,29 +17,29 @@
 /datum/speech_module_tree/auxiliary/process()
 	return
 
-/datum/speech_module_tree/auxiliary/_AddOutput(output_id, arguments, count)
-	src.target_speech_tree?._AddOutput(output_id, arguments, count)
+/datum/speech_module_tree/auxiliary/_AddSpeechOutput(output_id, arguments, count)
+	src.target_speech_tree?._AddSpeechOutput(output_id, arguments, count)
 	. = ..()
 
-/datum/speech_module_tree/auxiliary/RemoveOutput(output_id, subchannel, count)
-	src.target_speech_tree?.RemoveOutput(output_id, subchannel, count)
+/datum/speech_module_tree/auxiliary/RemoveSpeechOutput(output_id, subchannel, count)
+	src.target_speech_tree?.RemoveSpeechOutput(output_id, subchannel, count)
 	. = ..()
 
-/datum/speech_module_tree/auxiliary/_AddModifier(modifier_id, arguments, count)
-	src.target_speech_tree?._AddModifier(modifier_id, arguments, count)
+/datum/speech_module_tree/auxiliary/_AddSpeechModifier(modifier_id, arguments, count)
+	src.target_speech_tree?._AddSpeechModifier(modifier_id, arguments, count)
 	. = ..()
 
-/datum/speech_module_tree/auxiliary/RemoveModifier(modifier_id, count)
-	src.target_speech_tree?.RemoveModifier(modifier_id, count)
+/datum/speech_module_tree/auxiliary/RemoveSpeechModifier(modifier_id, count)
+	src.target_speech_tree?.RemoveSpeechModifier(modifier_id, count)
 	. = ..()
 
 /datum/speech_module_tree/auxiliary/proc/update_target_speech_tree(datum/speech_module_tree/speech_tree)
 	if (src.target_speech_tree)
 		for (var/output_id in src.output_module_ids_with_subcount)
-			src.target_speech_tree.RemoveOutput(output_id, count = src.output_module_ids_with_subcount[output_id])
+			src.target_speech_tree.RemoveSpeechOutput(output_id, count = src.output_module_ids_with_subcount[output_id])
 
 		for (var/modifier_id in src.speech_modifier_ids_with_subcount)
-			src.target_speech_tree.RemoveModifier(modifier_id, count = src.speech_modifier_ids_with_subcount[modifier_id])
+			src.target_speech_tree.RemoveSpeechModifier(modifier_id, count = src.speech_modifier_ids_with_subcount[modifier_id])
 
 		src.target_speech_tree.auxiliary_trees -= src
 
@@ -48,9 +48,9 @@
 		return
 
 	for (var/output_id in src.output_module_ids_with_subcount)
-		src.target_speech_tree._AddOutput(output_id, count = src.output_module_ids_with_subcount[output_id])
+		src.target_speech_tree._AddSpeechOutput(output_id, count = src.output_module_ids_with_subcount[output_id])
 
 	for (var/modifier_id in src.speech_modifier_ids_with_subcount)
-		src.target_speech_tree._AddModifier(modifier_id, count = src.speech_modifier_ids_with_subcount[modifier_id])
+		src.target_speech_tree._AddSpeechModifier(modifier_id, count = src.speech_modifier_ids_with_subcount[modifier_id])
 
 	src.target_speech_tree.auxiliary_trees += src

--- a/code/modules/speech/trees/auxiliary_speech_module_tree.dm
+++ b/code/modules/speech/trees/auxiliary_speech_module_tree.dm
@@ -17,29 +17,29 @@
 /datum/speech_module_tree/auxiliary/process()
 	return
 
-/datum/speech_module_tree/auxiliary/AddOutput(output_id)
-	src.target_speech_tree?.AddOutput(output_id)
+/datum/speech_module_tree/auxiliary/_AddOutput(output_id, arguments, count)
+	src.target_speech_tree?._AddOutput(output_id, arguments, count)
 	. = ..()
 
-/datum/speech_module_tree/auxiliary/RemoveOutput(output_id)
-	src.target_speech_tree?.RemoveOutput(output_id)
+/datum/speech_module_tree/auxiliary/RemoveOutput(output_id, subchannel, count)
+	src.target_speech_tree?.RemoveOutput(output_id, subchannel, count)
 	. = ..()
 
-/datum/speech_module_tree/auxiliary/AddModifier(modifier_id)
-	src.target_speech_tree?.AddModifier(modifier_id)
+/datum/speech_module_tree/auxiliary/_AddModifier(modifier_id, arguments, count)
+	src.target_speech_tree?._AddModifier(modifier_id, arguments, count)
 	. = ..()
 
-/datum/speech_module_tree/auxiliary/RemoveModifier(modifier_id)
-	src.target_speech_tree?.RemoveModifier(modifier_id)
+/datum/speech_module_tree/auxiliary/RemoveModifier(modifier_id, count)
+	src.target_speech_tree?.RemoveModifier(modifier_id, count)
 	. = ..()
 
 /datum/speech_module_tree/auxiliary/proc/update_target_speech_tree(datum/speech_module_tree/speech_tree)
 	if (src.target_speech_tree)
 		for (var/output_id in src.output_module_ids_with_subcount)
-			src.target_speech_tree.RemoveOutput(output_id, src.output_module_ids_with_subcount[output_id])
+			src.target_speech_tree.RemoveOutput(output_id, count = src.output_module_ids_with_subcount[output_id])
 
 		for (var/modifier_id in src.speech_modifier_ids_with_subcount)
-			src.target_speech_tree.RemoveModifier(modifier_id, src.speech_modifier_ids_with_subcount[modifier_id])
+			src.target_speech_tree.RemoveModifier(modifier_id, count = src.speech_modifier_ids_with_subcount[modifier_id])
 
 		src.target_speech_tree.auxiliary_trees -= src
 
@@ -48,9 +48,9 @@
 		return
 
 	for (var/output_id in src.output_module_ids_with_subcount)
-		src.target_speech_tree.AddOutput(output_id, src.output_module_ids_with_subcount[output_id])
+		src.target_speech_tree._AddOutput(output_id, count = src.output_module_ids_with_subcount[output_id])
 
 	for (var/modifier_id in src.speech_modifier_ids_with_subcount)
-		src.target_speech_tree.AddModifier(modifier_id, src.speech_modifier_ids_with_subcount[modifier_id])
+		src.target_speech_tree._AddModifier(modifier_id, count = src.speech_modifier_ids_with_subcount[modifier_id])
 
 	src.target_speech_tree.auxiliary_trees += src

--- a/code/modules/speech/trees/listen_module_tree.dm
+++ b/code/modules/speech/trees/listen_module_tree.dm
@@ -9,34 +9,34 @@
 	/// The atom that should act as the origin point for listening to messages.
 	var/atom/listener_origin
 	/// A list of all atoms that list this listen module tree as their listen tree, despite not being the true parent.
-	var/list/atom/secondary_parents
+	VAR_PROTECTED/list/atom/secondary_parents
 	/// A list of all auxiliary listen module trees with this listen module tree registered as a target.
-	var/list/datum/listen_module_tree/auxiliary/auxiliary_trees
+	VAR_PROTECTED/list/datum/listen_module_tree/auxiliary/auxiliary_trees
 	/// A temporary buffer of all received messages that are to be outputted to the parent when the buffer is flushed.
-	var/list/datum/say_message/message_buffer
+	VAR_PROTECTED/list/datum/say_message/message_buffer
 	/// An associative list of all signal recipients that may cause the message buffer to flush.
-	var/list/datum/signal_recipients
+	VAR_PROTECTED/list/datum/signal_recipients
 
 	/// An associative list of input listen module subscription counts, indexed by the module ID.
-	var/list/input_module_ids_with_subcount
+	VAR_PROTECTED/list/input_module_ids_with_subcount
 	/// An associative list of input listen modules, indexed by the module ID.
-	var/list/datum/listen_module/input/input_modules_by_id
+	VAR_PROTECTED/list/datum/listen_module/input/input_modules_by_id
 	/// An associative list of input listen modules, indexed by the module channel.
-	var/list/list/datum/listen_module/input/input_modules_by_channel
+	VAR_PROTECTED/list/list/datum/listen_module/input/input_modules_by_channel
 
 	/// An associative list of modifier listen module subscription counts, indexed by the module ID.
-	var/list/listen_modifier_ids_with_subcount
+	VAR_PROTECTED/list/listen_modifier_ids_with_subcount
 	/// An associative list of modifier listen modules, indexed by the module ID.
-	var/list/datum/listen_module/modifier/listen_modifiers_by_id
+	VAR_PROTECTED/list/datum/listen_module/modifier/listen_modifiers_by_id
 	/// An associative list of modifier listen modules that overide say channel modifier preferences, indexed by the module ID.
-	var/list/datum/speech_module/modifier/persistent_listen_modifiers_by_id
+	VAR_PROTECTED/list/datum/speech_module/modifier/persistent_listen_modifiers_by_id
 
 	/// An associative list of language datum subscription counts, indexed by the language ID.
-	var/list/known_language_ids_with_subcount
+	VAR_PROTECTED/list/known_language_ids_with_subcount
 	/// An associative list of language datums, indexed by the language ID.
-	var/list/datum/language/known_languages_by_id
+	VAR_PROTECTED/list/datum/language/known_languages_by_id
 	/// Whether this listen module tree is capable of understanding all languages.
-	var/understands_all_languages = FALSE
+	VAR_PROTECTED/understands_all_languages = FALSE
 
 /datum/listen_module_tree/New(atom/parent, list/inputs = list(), list/modifiers = list(), list/languages = list())
 	. = ..()
@@ -178,54 +178,58 @@
 	SEND_SIGNAL(src, COMSIG_LISTENER_ORIGIN_UPDATED, old_origin, new_origin)
 
 /// Adds a new input module to the tree. Returns a reference to the new input module on success.
-/datum/listen_module_tree/proc/AddInput(input_id, count = 1)
+/datum/listen_module_tree/proc/_AddInput(input_id, list/arguments = list(), count = 1)
 	RETURN_TYPE(/datum/listen_module/input)
 
-	src.input_module_ids_with_subcount[input_id] += count
-	if (src.input_modules_by_id[input_id])
-		return src.input_modules_by_id[input_id]
+	var/module_id = "[input_id][(arguments["subchannel"] || "")]"
+	src.input_module_ids_with_subcount[module_id] += count
+	if (src.input_modules_by_id[module_id])
+		return src.input_modules_by_id[module_id]
 
-	var/datum/listen_module/input/new_input = global.SpeechManager.GetInputInstance(input_id, src)
+	arguments["parent"] = src
+	var/datum/listen_module/input/new_input = global.SpeechManager.GetInputInstance(input_id, arguments)
 	if (!istype(new_input))
 		return
 
-	src.input_modules_by_id[input_id] = new_input
+	src.input_modules_by_id[module_id] = new_input
 	src.input_modules_by_channel[new_input.channel] ||= list()
 	src.input_modules_by_channel[new_input.channel] += new_input
 	return new_input
 
 /// Removes an input from the tree. Returns TRUE on success, FALSE on failure.
-/datum/listen_module_tree/proc/RemoveInput(input_id, count = 1)
-	if (!src.input_modules_by_id[input_id])
+/datum/listen_module_tree/proc/RemoveInput(input_id, subchannel = "", count = 1)
+	var/module_id = "[input_id][subchannel]"
+	if (!src.input_modules_by_id[module_id])
 		return FALSE
 
-	src.input_module_ids_with_subcount[input_id] -= count
-	if (!src.input_module_ids_with_subcount[input_id])
-		src.input_modules_by_channel[src.input_modules_by_id[input_id].channel] -= src.input_modules_by_id[input_id]
-		qdel(src.input_modules_by_id[input_id])
-		src.input_modules_by_id -= input_id
+	src.input_module_ids_with_subcount[module_id] -= count
+	if (!src.input_module_ids_with_subcount[module_id])
+		src.input_modules_by_channel[src.input_modules_by_id[module_id].channel] -= src.input_modules_by_id[module_id]
+		qdel(src.input_modules_by_id[module_id])
+		src.input_modules_by_id -= module_id
 
 	return TRUE
 
 /// Returns the input module that matches the specified ID.
-/datum/listen_module_tree/proc/GetInputByID(input_id)
+/datum/listen_module_tree/proc/GetInputByID(input_id, subchannel = "")
 	RETURN_TYPE(/datum/listen_module/input)
-	return src.input_modules_by_id[input_id]
+	return src.input_modules_by_id["[input_id][subchannel]"]
 
 /// Returns a list of output modules that output to the specified channel.
-/datum/listen_module_tree/proc/GetInputByChannel(channel_id)
+/datum/listen_module_tree/proc/GetInputsByChannel(channel_id)
 	RETURN_TYPE(/list/datum/listen_module/input)
 	return src.input_modules_by_channel[channel_id]
 
 /// Adds a new modifier module to the tree. Returns a reference to the new modifier module on success.
-/datum/listen_module_tree/proc/AddModifier(modifier_id, count = 1)
+/datum/listen_module_tree/proc/_AddModifier(modifier_id, list/arguments = list(), count = 1)
 	RETURN_TYPE(/datum/listen_module/modifier)
 
 	src.listen_modifier_ids_with_subcount[modifier_id] += count
 	if (src.listen_modifiers_by_id[modifier_id])
 		return src.listen_modifiers_by_id[modifier_id]
 
-	var/datum/listen_module/modifier/new_modifier = global.SpeechManager.GetListenModifierInstance(modifier_id, src)
+	arguments["parent"] = src
+	var/datum/listen_module/modifier/new_modifier = global.SpeechManager.GetListenModifierInstance(modifier_id, arguments)
 	if (!istype(new_modifier))
 		return
 

--- a/code/modules/speech/trees/listen_module_tree.dm
+++ b/code/modules/speech/trees/listen_module_tree.dm
@@ -52,13 +52,13 @@
 	src.input_modules_by_id = list()
 	src.input_modules_by_channel = list()
 	for (var/input_id in inputs)
-		src.AddInput(input_id)
+		src.AddListenInput(input_id)
 
 	src.listen_modifier_ids_with_subcount = list()
 	src.listen_modifiers_by_id = list()
 	src.persistent_listen_modifiers_by_id = list()
 	for (var/modifier_id in modifiers)
-		src.AddModifier(modifier_id)
+		src.AddListenModifier(modifier_id)
 
 	src.known_language_ids_with_subcount = list()
 	src.known_languages_by_id = list()
@@ -178,7 +178,7 @@
 	SEND_SIGNAL(src, COMSIG_LISTENER_ORIGIN_UPDATED, old_origin, new_origin)
 
 /// Adds a new input module to the tree. Returns a reference to the new input module on success.
-/datum/listen_module_tree/proc/_AddInput(input_id, list/arguments = list(), count = 1)
+/datum/listen_module_tree/proc/_AddListenInput(input_id, list/arguments = list(), count = 1)
 	RETURN_TYPE(/datum/listen_module/input)
 
 	var/module_id = "[input_id][arguments["subchannel"]]"
@@ -197,7 +197,7 @@
 	return new_input
 
 /// Removes an input from the tree. Returns TRUE on success, FALSE on failure.
-/datum/listen_module_tree/proc/RemoveInput(input_id, subchannel, count = 1)
+/datum/listen_module_tree/proc/RemoveListenInput(input_id, subchannel, count = 1)
 	var/module_id = "[input_id][subchannel]"
 	if (!src.input_modules_by_id[module_id])
 		return FALSE
@@ -221,7 +221,7 @@
 	return src.input_modules_by_channel[channel_id]
 
 /// Adds a new modifier module to the tree. Returns a reference to the new modifier module on success.
-/datum/listen_module_tree/proc/_AddModifier(modifier_id, list/arguments = list(), count = 1)
+/datum/listen_module_tree/proc/_AddListenModifier(modifier_id, list/arguments = list(), count = 1)
 	RETURN_TYPE(/datum/listen_module/modifier)
 
 	src.listen_modifier_ids_with_subcount[modifier_id] += count
@@ -243,7 +243,7 @@
 	return new_modifier
 
 /// Removes a modifier from the tree. Returns TRUE on success, FALSE on failure.
-/datum/listen_module_tree/proc/RemoveModifier(modifier_id, count = 1)
+/datum/listen_module_tree/proc/RemoveListenModifier(modifier_id, count = 1)
 	if (!src.listen_modifiers_by_id[modifier_id])
 		return FALSE
 

--- a/code/modules/speech/trees/listen_module_tree.dm
+++ b/code/modules/speech/trees/listen_module_tree.dm
@@ -181,7 +181,7 @@
 /datum/listen_module_tree/proc/_AddInput(input_id, list/arguments = list(), count = 1)
 	RETURN_TYPE(/datum/listen_module/input)
 
-	var/module_id = "[input_id][(arguments["subchannel"] || "")]"
+	var/module_id = "[input_id][arguments["subchannel"]]"
 	src.input_module_ids_with_subcount[module_id] += count
 	if (src.input_modules_by_id[module_id])
 		return src.input_modules_by_id[module_id]
@@ -197,7 +197,7 @@
 	return new_input
 
 /// Removes an input from the tree. Returns TRUE on success, FALSE on failure.
-/datum/listen_module_tree/proc/RemoveInput(input_id, subchannel = "", count = 1)
+/datum/listen_module_tree/proc/RemoveInput(input_id, subchannel, count = 1)
 	var/module_id = "[input_id][subchannel]"
 	if (!src.input_modules_by_id[module_id])
 		return FALSE
@@ -211,7 +211,7 @@
 	return TRUE
 
 /// Returns the input module that matches the specified ID.
-/datum/listen_module_tree/proc/GetInputByID(input_id, subchannel = "")
+/datum/listen_module_tree/proc/GetInputByID(input_id, subchannel)
 	RETURN_TYPE(/datum/listen_module/input)
 	return src.input_modules_by_id["[input_id][subchannel]"]
 

--- a/code/modules/speech/trees/speech_module_tree.dm
+++ b/code/modules/speech/trees/speech_module_tree.dm
@@ -39,13 +39,13 @@
 	src.output_modules_by_id = list()
 	src.output_modules_by_channel = list()
 	for (var/output_id in outputs)
-		src.AddOutput(output_id)
+		src.AddSpeechOutput(output_id)
 
 	src.speech_modifier_ids_with_subcount = list()
 	src.speech_modifiers_by_id = list()
 	src.persistent_speech_modifiers_by_id = list()
 	for (var/modifier_id in modifiers)
-		src.AddModifier(modifier_id)
+		src.AddSpeechModifier(modifier_id)
 
 /datum/speech_module_tree/disposing()
 	for (var/datum/speech_module_tree/auxiliary/auxiliary_tree as anything in src.auxiliary_trees)
@@ -177,7 +177,7 @@
 	SEND_SIGNAL(src, COMSIG_SPEAKER_ORIGIN_UPDATED, old_origin, new_origin)
 
 /// Adds a new output module to the tree. Returns a reference to the new output module on success.
-/datum/speech_module_tree/proc/_AddOutput(output_id, list/arguments = list(), count = 1)
+/datum/speech_module_tree/proc/_AddSpeechOutput(output_id, list/arguments = list(), count = 1)
 	RETURN_TYPE(/datum/speech_module/output)
 
 	var/module_id = "[output_id][arguments["subchannel"]]"
@@ -197,7 +197,7 @@
 	return new_output
 
 /// Removes an output module from the tree. Returns TRUE on success, FALSE on failure.
-/datum/speech_module_tree/proc/RemoveOutput(output_id, subchannel, count = 1)
+/datum/speech_module_tree/proc/RemoveSpeechOutput(output_id, subchannel, count = 1)
 	var/module_id = "[output_id][subchannel]"
 	if (!src.output_modules_by_id[module_id])
 		return FALSE
@@ -221,7 +221,7 @@
 	return src.output_modules_by_channel[channel_id]
 
 /// Adds a new modifier module to the tree. Returns a reference to the new modifier module on success.
-/datum/speech_module_tree/proc/_AddModifier(modifier_id, list/arguments = list(), count = 1)
+/datum/speech_module_tree/proc/_AddSpeechModifier(modifier_id, list/arguments = list(), count = 1)
 	RETURN_TYPE(/datum/speech_module/modifier)
 
 	src.speech_modifier_ids_with_subcount[modifier_id] += count
@@ -243,7 +243,7 @@
 	return new_modifier
 
 /// Removes a modifier from the tree. Returns TRUE on success, FALSE on failure.
-/datum/speech_module_tree/proc/RemoveModifier(modifier_id, count = 1)
+/datum/speech_module_tree/proc/RemoveSpeechModifier(modifier_id, count = 1)
 	if (!src.speech_modifiers_by_id[modifier_id])
 		return FALSE
 

--- a/code/modules/speech/trees/speech_module_tree.dm
+++ b/code/modules/speech/trees/speech_module_tree.dm
@@ -180,7 +180,7 @@
 /datum/speech_module_tree/proc/_AddOutput(output_id, list/arguments = list(), count = 1)
 	RETURN_TYPE(/datum/speech_module/output)
 
-	var/module_id = "[output_id][(arguments["subchannel"] || "")]"
+	var/module_id = "[output_id][arguments["subchannel"]]"
 	src.output_module_ids_with_subcount[module_id] += count
 	if (src.output_modules_by_id[module_id])
 		return src.output_modules_by_id[module_id]
@@ -197,7 +197,7 @@
 	return new_output
 
 /// Removes an output module from the tree. Returns TRUE on success, FALSE on failure.
-/datum/speech_module_tree/proc/RemoveOutput(output_id, subchannel = "", count = 1)
+/datum/speech_module_tree/proc/RemoveOutput(output_id, subchannel, count = 1)
 	var/module_id = "[output_id][subchannel]"
 	if (!src.output_modules_by_id[module_id])
 		return FALSE
@@ -211,7 +211,7 @@
 	return TRUE
 
 /// Returns the output module that matches the specified ID.
-/datum/speech_module_tree/proc/GetOutputByID(output_id, subchannel = "")
+/datum/speech_module_tree/proc/GetOutputByID(output_id, subchannel)
 	RETURN_TYPE(/datum/speech_module/output)
 	return src.output_modules_by_id["[output_id][subchannel]"]
 

--- a/code/modules/speech/trees/speech_module_tree.dm
+++ b/code/modules/speech/trees/speech_module_tree.dm
@@ -9,23 +9,23 @@
 	/// The atom that should act as the origin point for sending messages from this speech module tree.
 	var/atom/speaker_origin
 	/// A list of all atoms that list this speech module tree as their say tree, despite not being the true parent.
-	var/list/atom/secondary_parents
+	VAR_PROTECTED/list/atom/secondary_parents
 	/// A list of all auxiliary speech module trees with this speech module tree registered as a target.
-	var/list/datum/speech_module_tree/auxiliary/auxiliary_trees
+	VAR_PROTECTED/list/datum/speech_module_tree/auxiliary/auxiliary_trees
 
 	/// An associative list of output speech module subscription counts, indexed by the module ID.
-	var/list/output_module_ids_with_subcount
+	VAR_PROTECTED/list/output_module_ids_with_subcount
 	/// An associative list of output speech modules, indexed by the module ID.
-	var/list/datum/speech_module/output/output_modules_by_id
+	VAR_PROTECTED/list/datum/speech_module/output/output_modules_by_id
 	/// An associative list of output speech modules, indexed by the module channel. Additionally, each sublist of modules is sorted by priority.
-	var/list/datum/speech_module/output/output_modules_by_channel
+	VAR_PROTECTED/list/datum/speech_module/output/output_modules_by_channel
 
 	/// An associative list of modifier speech module subscription counts, indexed by the module ID.
-	var/list/speech_modifier_ids_with_subcount
+	VAR_PROTECTED/list/speech_modifier_ids_with_subcount
 	/// An associative list of modifier speech modules, indexed by the module ID.
-	var/list/datum/speech_module/modifier/speech_modifiers_by_id
+	VAR_PROTECTED/list/datum/speech_module/modifier/speech_modifiers_by_id
 	/// An associative list of modifier speech modules that overide say channel modifier preferences, indexed by the module ID.
-	var/list/datum/speech_module/modifier/persistent_speech_modifiers_by_id
+	VAR_PROTECTED/list/datum/speech_module/modifier/persistent_speech_modifiers_by_id
 
 /datum/speech_module_tree/New(atom/parent, list/modifiers = list(), list/outputs = list())
 	. = ..()
@@ -86,7 +86,7 @@
 		if (output_override)
 			output_modules = list(output_override)
 	else
-		output_modules = src.GetOutputByChannel(message.output_module_channel)
+		output_modules = src.GetOutputsByChannel(message.output_module_channel)
 
 	if (!length(output_modules))
 		return
@@ -177,55 +177,59 @@
 	SEND_SIGNAL(src, COMSIG_SPEAKER_ORIGIN_UPDATED, old_origin, new_origin)
 
 /// Adds a new output module to the tree. Returns a reference to the new output module on success.
-/datum/speech_module_tree/proc/AddOutput(output_id, count = 1)
+/datum/speech_module_tree/proc/_AddOutput(output_id, list/arguments = list(), count = 1)
 	RETURN_TYPE(/datum/speech_module/output)
 
-	src.output_module_ids_with_subcount[output_id] += count
-	if (src.output_modules_by_id[output_id])
-		return src.output_modules_by_id[output_id]
+	var/module_id = "[output_id][(arguments["subchannel"] || "")]"
+	src.output_module_ids_with_subcount[module_id] += count
+	if (src.output_modules_by_id[module_id])
+		return src.output_modules_by_id[module_id]
 
-	var/datum/speech_module/output/new_output = global.SpeechManager.GetOutputInstance(output_id, src)
+	arguments["parent"] = src
+	var/datum/speech_module/output/new_output = global.SpeechManager.GetOutputInstance(output_id, arguments)
 	if (!istype(new_output))
 		return
 
-	src.output_modules_by_id[output_id] = new_output
+	src.output_modules_by_id[module_id] = new_output
 	src.output_modules_by_channel[new_output.channel] ||= list()
 	src.output_modules_by_channel[new_output.channel] += new_output
 	sortList(src.output_modules_by_channel[new_output.channel], GLOBAL_PROC_REF(cmp_say_modules))
 	return new_output
 
 /// Removes an output module from the tree. Returns TRUE on success, FALSE on failure.
-/datum/speech_module_tree/proc/RemoveOutput(output_id, count = 1)
-	if (!src.output_modules_by_id[output_id])
+/datum/speech_module_tree/proc/RemoveOutput(output_id, subchannel = "", count = 1)
+	var/module_id = "[output_id][subchannel]"
+	if (!src.output_modules_by_id[module_id])
 		return FALSE
 
-	src.output_module_ids_with_subcount[output_id] -= count
-	if (!src.output_module_ids_with_subcount[output_id])
-		src.output_modules_by_channel[src.output_modules_by_id[output_id].channel] -= src.output_modules_by_id[output_id]
-		qdel(src.output_modules_by_id[output_id])
-		src.output_modules_by_id -= output_id
+	src.output_module_ids_with_subcount[module_id] -= count
+	if (!src.output_module_ids_with_subcount[module_id])
+		src.output_modules_by_channel[src.output_modules_by_id[module_id].channel] -= src.output_modules_by_id[module_id]
+		qdel(src.output_modules_by_id[module_id])
+		src.output_modules_by_id -= module_id
 
 	return TRUE
 
 /// Returns the output module that matches the specified ID.
-/datum/speech_module_tree/proc/GetOutputByID(output_id)
+/datum/speech_module_tree/proc/GetOutputByID(output_id, subchannel = "")
 	RETURN_TYPE(/datum/speech_module/output)
-	return src.output_modules_by_id[output_id]
+	return src.output_modules_by_id["[output_id][subchannel]"]
 
 /// Returns a list of output modules that output to the specified channel.
-/datum/speech_module_tree/proc/GetOutputByChannel(channel_id)
+/datum/speech_module_tree/proc/GetOutputsByChannel(channel_id)
 	RETURN_TYPE(/list/datum/speech_module/output)
 	return src.output_modules_by_channel[channel_id]
 
 /// Adds a new modifier module to the tree. Returns a reference to the new modifier module on success.
-/datum/speech_module_tree/proc/AddModifier(modifier_id, count = 1)
+/datum/speech_module_tree/proc/_AddModifier(modifier_id, list/arguments = list(), count = 1)
 	RETURN_TYPE(/datum/speech_module/modifier)
 
 	src.speech_modifier_ids_with_subcount[modifier_id] += count
 	if (src.speech_modifiers_by_id[modifier_id])
 		return src.speech_modifiers_by_id[modifier_id]
 
-	var/datum/speech_module/modifier/new_modifier = global.SpeechManager.GetSpeechModifierInstance(modifier_id)
+	arguments["parent"] = src
+	var/datum/speech_module/modifier/new_modifier = global.SpeechManager.GetSpeechModifierInstance(modifier_id, arguments)
 	if (!istype(new_modifier))
 		return
 

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -910,7 +910,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item)
 
 	return
 
-/obj/machinery/vending/say(message, flags, message_params, atom_listeners_override)
+/obj/machinery/vending/say(message, flags, list/message_params, list/atom/atom_listeners_override)
 	if (src.status & NOPOWER)
 		return
 

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -25,7 +25,7 @@ TYPEINFO(/obj/flock_structure)
 	start_listen_modifiers = null
 	start_listen_inputs = null
 	start_speech_modifiers = null
-	start_speech_outputs = list(SPEECH_OUTPUT_FLOCK_SYSTEM)
+	start_speech_outputs = null
 	default_speech_output_channel = SAY_CHANNEL_FLOCK
 	start_listen_languages = list(LANGUAGE_ALL)
 	say_language = LANGUAGE_FEATHER

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -428,7 +428,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	// Clown's Revenge and Cluwning Around take care of every other scenario (Convair880).
 	src.cant_self_remove = TRUE
 	src.cant_other_remove = TRUE
-	user.ensure_say_tree().AddModifier(SPEECH_MODIFIER_ACCENT_CLUWNE)
+	user.ensure_say_tree().AddSpeechModifier(SPEECH_MODIFIER_ACCENT_CLUWNE)
 
 	if(src.infectious && user.reagents)
 		user.reagents.add_reagent("painbow fluid", 10)
@@ -436,7 +436,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 
 /obj/item/clothing/mask/cursedclown_hat/unequipped(mob/user)
 	if (src.equipped_in_slot == SLOT_WEAR_MASK)
-		user.ensure_say_tree().RemoveModifier(SPEECH_MODIFIER_ACCENT_CLUWNE)
+		user.ensure_say_tree().RemoveSpeechModifier(SPEECH_MODIFIER_ACCENT_CLUWNE)
 
 	. = ..()
 
@@ -757,11 +757,11 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 			if (slot != SLOT_WEAR_MASK)
 				return
 
-			user.ensure_say_tree().AddModifier(SPEECH_MODIFIER_ACCENT_HORSE)
+			user.ensure_say_tree().AddSpeechModifier(SPEECH_MODIFIER_ACCENT_HORSE)
 
 		unequipped(mob/user)
 			if (src.equipped_in_slot == SLOT_WEAR_MASK)
-				user.ensure_say_tree().RemoveModifier(SPEECH_MODIFIER_ACCENT_HORSE)
+				user.ensure_say_tree().RemoveSpeechModifier(SPEECH_MODIFIER_ACCENT_HORSE)
 
 			. = ..()
 

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -498,11 +498,11 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 		if (slot != SLOT_WEAR_MASK)
 			return
 
-		user.ensure_say_tree().AddModifier(SPEECH_MODIFIER_MUZZLE)
+		user.ensure_say_tree().AddSpeechModifier(SPEECH_MODIFIER_MUZZLE)
 
 	unequipped(mob/user)
 		if (src.equipped_in_slot == SLOT_WEAR_MASK)
-			user.ensure_say_tree().RemoveModifier(SPEECH_MODIFIER_MUZZLE)
+			user.ensure_say_tree().RemoveSpeechModifier(SPEECH_MODIFIER_MUZZLE)
 
 		. = ..()
 

--- a/code/obj/item/device/megaphone.dm
+++ b/code/obj/item/device/megaphone.dm
@@ -21,10 +21,10 @@
 	pickup(mob/M)
 		. = ..()
 
-		M.ensure_say_tree().AddModifier(SPEECH_MODIFIER_MEGAPHONE)
+		M.ensure_say_tree().AddSpeechModifier(SPEECH_MODIFIER_MEGAPHONE)
 
 	dropped(mob/M)
-		M.ensure_say_tree().RemoveModifier(SPEECH_MODIFIER_MEGAPHONE)
+		M.ensure_say_tree().RemoveSpeechModifier(SPEECH_MODIFIER_MEGAPHONE)
 
 		. = ..()
 

--- a/code/obj/item/device/radios/_radio.dm
+++ b/code/obj/item/device/radios/_radio.dm
@@ -355,9 +355,9 @@ TYPEINFO(/obj/item/device/radio)
 
 	src.ensure_listen_tree()
 	if (src.microphone_enabled)
-		src.listen_tree.AddInput(src.microphone_listen_input)
+		src.listen_tree.AddListenInput(src.microphone_listen_input)
 	else
-		src.listen_tree.RemoveInput(src.microphone_listen_input)
+		src.listen_tree.RemoveListenInput(src.microphone_listen_input)
 
 /// Toggles the radio speaker, determining whether received radio messages should be spoken.
 /obj/item/device/radio/proc/toggle_speaker(speaker_enabled)

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -335,13 +335,13 @@ TYPEINFO(/obj/item/device/radio/intercom)
 
 /obj/item/device/radio/intercom/fish/combust()
 	if (!src.burning)
-		src.ensure_say_tree().AddModifier("stutter")
+		src.ensure_say_tree().AddSpeechModifier("stutter")
 
 	. = ..()
 
 /obj/item/device/radio/intercom/fish/combust_ended()
 	if (!src.burning)
-		src.ensure_say_tree().RemoveModifier("stutter")
+		src.ensure_say_tree().RemoveSpeechModifier("stutter")
 	. = ..()
 
 /obj/item/device/radio/intercom/fish/update_pixel_offset_dir()

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -816,8 +816,8 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		if (!istype(M))
 			return
 
-		M.ensure_say_tree().AddOutput(SPEECH_OUTPUT_SILICONCHAT)
-		M.ensure_listen_tree().AddInput(LISTEN_INPUT_SILICONCHAT)
+		M.ensure_say_tree().AddSpeechOutput(SPEECH_OUTPUT_SILICONCHAT)
+		M.ensure_listen_tree().AddListenInput(LISTEN_INPUT_SILICONCHAT)
 		M.listen_tree.AddKnownLanguage(LANGUAGE_SILICON)
 		M.listen_tree.AddKnownLanguage(LANGUAGE_BINARY)
 
@@ -827,8 +827,8 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		if (!istype(M))
 			return
 
-		M.ensure_say_tree().RemoveOutput(SPEECH_OUTPUT_SILICONCHAT)
-		M.ensure_listen_tree().RemoveInput(LISTEN_INPUT_SILICONCHAT)
+		M.ensure_say_tree().RemoveSpeechOutput(SPEECH_OUTPUT_SILICONCHAT)
+		M.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_SILICONCHAT)
 		M.listen_tree.RemoveKnownLanguage(LANGUAGE_SILICON)
 		M.listen_tree.RemoveKnownLanguage(LANGUAGE_BINARY)
 

--- a/code/obj/machinery/door/door_control.dm
+++ b/code/obj/machinery/door/door_control.dm
@@ -508,7 +508,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door_control, proc/toggle)
 	else
 		boutput(user, "<span class='alert'>It's broken.</span>")
 
-/obj/machinery/door_control/say(message, flags, message_params, atom_listeners_override)
+/obj/machinery/door_control/say(message, flags, list/message_params, list/atom/atom_listeners_override)
 	if (src.status & NOPOWER)
 		return
 

--- a/code/obj/zoldorf.dm
+++ b/code/obj/zoldorf.dm
@@ -351,7 +351,7 @@ var/global/list/mob/zoldorf/the_zoldorf = list() //for some reason a global mob 
 			o2.layer = 5
 			src.vis_contents += o2
 
-			z.ensure_listen_tree().AddInput(LISTEN_INPUT_DEADCHAT)
+			z.ensure_listen_tree().AddListenInput(LISTEN_INPUT_DEADCHAT)
 			boutput(z, SPAN_NOTICE("<b>You begin to hear the whisperings of the dead...</b>"))
 
 			for(var/i=1,i<=6,i++)
@@ -366,7 +366,7 @@ var/global/list/mob/zoldorf/the_zoldorf = list() //for some reason a global mob 
 
 			if(src)
 				if(z.loc == src)
-					z.ensure_listen_tree().RemoveInput(LISTEN_INPUT_DEADCHAT)
+					z.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_DEADCHAT)
 					boutput(z, SPAN_NOTICE("<b>The whispers and wails of those parted fade into nothingness...</b>"))
 				src.lightfade()
 				src.remove_simple_light("zoldorf")

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -287,9 +287,9 @@
 	usr.client.mute_ghost_radio = !usr.client.mute_ghost_radio
 
 	if (usr.client.mute_ghost_radio)
-		src.ensure_listen_tree().RemoveInput(LISTEN_INPUT_RADIO_GLOBAL)
+		src.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_RADIO_GLOBAL)
 	else
-		src.ensure_listen_tree().AddInput(LISTEN_INPUT_RADIO_GLOBAL)
+		src.ensure_listen_tree().AddListenInput(LISTEN_INPUT_RADIO_GLOBAL)
 
 	boutput(usr, SPAN_NOTICE("[usr.client.mute_ghost_radio ? "No longer" : "Now"] hearing radio as a ghost."))
 


### PR DESCRIPTION
## About The PR:
Speech and listen module trees may now possess multiple instances of the same delimited module type, provided they have differing subchannels. In order to accommodate for this, `AddOutput()`, `AddInput()`, and `AddModifier()` have all been replaced by variadic macros that pass an arbitrary number of named arguments to the tree, then to the module to be instantiated. The wrappers operate in a similar manner to the `AddComponent()` wrapper macro.

Additionally, `ChangeChannel()` and `ChangeSubchannel()` have both been deprecated, variables and procs that lacked the `VAR_PROTECTED` and `RETURN_TYPE` macros now possess them, and other miscellaneous cleanup.