### PR TITLE
Fix localsay logging, log types, and log the location of spoken text

### DIFF
--- a/code/modules/speech/say_channels/_say_channel_parent.dm
+++ b/code/modules/speech/say_channels/_say_channel_parent.dm
@@ -30,6 +30,7 @@ ABSTRACT_TYPE(/datum/say_channel)
 
 /// The primary entry point for say message datums; they will be passed to this channel through this proc.
 /datum/say_channel/proc/PassToChannel(datum/say_message/message)
+	src.log_message(message)
 	src.PassToListeners(message, src.listeners)
 
 /// Pass a message to all listen modules in a specified list, indexed in sublists by type.
@@ -85,7 +86,17 @@ ABSTRACT_TYPE(/datum/say_channel)
 	if (!istype(M) || !M.client || !(message.flags & SAYFLAG_SPOKEN_BY_PLAYER))
 		return
 
-	logTheThing(LOG_SAY, message.speaker, "([src.channel_id]): [message.content]")
+	var/log_type = LOG_SAY
+	if (message.flags & SAYFLAG_WHISPER)
+		log_type = LOG_WHISPER
+
+	var/channel_name = src.channel_id
+	if (src.channel_id == SAY_CHANNEL_GLOBAL_OUTLOUD)
+		channel_name = "SAY"
+		if (message.flags & SAYFLAG_WHISPER)
+			channel_name = "WHISPER"
+
+	logTheThing(log_type, message.speaker, "[channel_name]: [message.prefix] [message.content] [log_loc(message.loc)]")
 	phrase_log.log_phrase("say", message.content)
 
 /// Set up an output module for sending messages over this channel.
@@ -135,12 +146,6 @@ ABSTRACT_TYPE(/datum/say_channel/global_channel)
 		return
 
 	src.delimited_channel.PassToListeners(message, src.delimited_channel.listeners, TRUE)
-
-/datum/say_channel/global_channel/log_message()
-	return
-
-
-
 
 
 ABSTRACT_TYPE(/datum/say_channel/delimited)

--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -10,6 +10,8 @@ var/regex/forbidden_character_regex = regex(@"[\u2028\u202a\u202b\u202c\u202d\u2
 	var/speaker_to_display = null
 	/// The text indicating where this message was spoken from, if it was spoken from inside of an object.
 	var/speaker_location_text = null
+	///  The location of where the message was sent, for logging.
+	var/loc = null
 	/// The sanitised and processed content of this message.
 	var/content = ""
 	/// The verb to display when this message is received, i.e: "Jeff [say_verb], [message]"
@@ -115,6 +117,7 @@ var/regex/forbidden_character_regex = regex(@"[\u2028\u202a\u202b\u202c\u202d\u2
 	src.speaker = speaker.speech_tree.speaker_parent
 	src.original_speaker = speaker.speech_tree.speaker_parent
 	src.message_origin = speaker.speech_tree.speaker_origin
+	src.loc = speaker.loc
 	src.id = "\ref[src]"
 	src.flags |= flags
 	src.atom_listeners_override = atom_listeners_override
@@ -393,6 +396,7 @@ var/regex/forbidden_character_regex = regex(@"[\u2028\u202a\u202b\u202c\u202d\u2
 	// Message Content & Format Variables:
 	copy.speaker_to_display = src.speaker_to_display
 	copy.speaker_location_text = src.speaker_location_text
+	copy.loc = src.loc
 	copy.content = src.content
 	copy.say_verb = src.say_verb
 	copy.whisper_verb = src.whisper_verb


### PR DESCRIPTION
* adds logging to the primary entry point
* removes a log_message override from `global_channel`
* adds a new var to say message: the loc of the atom that spoke
  * set in new, and copied over
* tweaks the log message to output to LOG_SAY or LOG_WHISPER as needed, and adds message prefix and location to logged message