### PR TITLE
Fix runtimes when using `ALL_ROBOT_AND_COMPUTERS_MUST_SHUT_THE_HELL_UP` define

### DIFF
--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -91,8 +91,6 @@ TYPEINFO(/obj/machinery/bot)
 			var/num = hex2num(copytext(md5("[src.name][TIME]"), 1, 7))
 			src.bot_speech_color = hsv2rgb(num % 360, (num / 360) % 10 + 18, num / 360 / 10 % 15 + 85)
 
-		src.ensure_speech_tree().AddSpeechModifier(SPEECH_MODIFIER_DECTALK_BOT)
-
 		SPAWN(0.5 SECONDS)
 			src.botcard = new /obj/item/card/id(src)
 			src.botcard.access = get_access(src.access_lookup)
@@ -101,6 +99,10 @@ TYPEINFO(/obj/machinery/bot)
 		#ifdef ALL_ROBOT_AND_COMPUTERS_MUST_SHUT_THE_HELL_UP
 		START_TRACKING_CAT(TR_CAT_DELETE_ME)
 		#endif
+
+	initialize()
+		. = ..()
+		src.ensure_speech_tree().AddSpeechModifier(SPEECH_MODIFIER_DECTALK_BOT)
 
 	disposing()
 		STOP_TRACKING


### PR DESCRIPTION
ensure the speech tree exists on `initialize` rather than `New`, otherwise we get an error from the proximity component